### PR TITLE
Refactored code calling BuildExpressionTree to enable the expression to be saved

### DIFF
--- a/Castle.DynamicLinqQueryBuilder.Tests/ExceptionAssert.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/ExceptionAssert.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             {
                 exceptionThrown = true;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
 
             }

--- a/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
@@ -4,8 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 using NUnit.Framework;
 
@@ -396,7 +394,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "in",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.ToString("MM/dd/yyyy") + "," + DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) + "," + DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -429,7 +427,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "in",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.ToString("MM/dd/yyyy") + "," + DateTime.UtcNow.Date.AddDays(1).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) + "," + DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -519,7 +517,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "in",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -731,7 +729,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "not_in",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.ToString("MM/dd/yyyy") + "," + DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) + "," + DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -764,7 +762,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "not_in",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.ToString("MM/dd/yyyy") + "," + DateTime.UtcNow.Date.AddDays(1).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) + "," + DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -854,7 +852,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "not_in",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -1119,7 +1117,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "is_empty",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -1225,7 +1223,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "is_not_empty",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -1580,7 +1578,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "equal",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -1613,7 +1611,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "equal",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -1855,7 +1853,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "not_equal",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -1888,7 +1886,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "not_equal",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2098,7 +2096,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "between",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy") + "," + DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture) + "," + DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2131,7 +2129,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "between",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy") + "," + DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture) + "," + DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2282,7 +2280,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "not_between",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy") + "," + DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture) + "," + DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2315,7 +2313,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "not_between",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy") + "," + DateTime.UtcNow.Date.ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture) + "," + DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2463,7 +2461,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "greater_or_equal",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2496,7 +2494,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "greater_or_equal",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2644,7 +2642,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "greater",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2677,7 +2675,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "greater",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2825,7 +2823,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "less",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -2858,7 +2856,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "less",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -3006,7 +3004,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "less_or_equal",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };
@@ -3039,7 +3037,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                         Input = "NA",
                         Operator = "less_or_equal",
                         Type = "datetime",
-                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("MM/dd/yyyy")
+                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
                     }
                 }
             };

--- a/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
@@ -3203,6 +3203,34 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
         }
         #endregion
 
+        #region Predicate
+        [Test]
+        public void Predicate_Test()
+        {
+            var rule = new FilterRule
+            {
+                Condition = "and",
+                Field = "ContentTypeId",
+                Id = "ContentTypeId",
+                Input = "NA",
+                Operator = "equal",
+                Type = "integer",
+                Value = "2",
+            };
+
+
+            var predicate = rule.BuildPredicate<IndexedClass>(new BuildExpressionOptions { IndexedPropertyName = "Item", UseIndexedProperty = true});
+
+            var result = new[] {new IndexedClass()}.Where(predicate);
+            Assert.IsTrue(result.Any());
+
+            rule.Value = "3";
+            result = new[] { new IndexedClass() }.BuildQuery(rule, true, "Item");
+            Assert.IsFalse(result.Any());
+        }
+        #endregion
+
+
         #region Column Definition Builder
 
         public class ColumnBuilderTestClass

--- a/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
@@ -1011,10 +1011,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             var contentTypeIdFilterList = startingQuery.BuildQuery(contentTypeIdFilter).ToList();
             Assert.IsTrue(contentTypeIdFilterList != null);
             Assert.IsTrue(contentTypeIdFilterList.Count == 0);
-            Assert.IsTrue(
-                contentTypeIdFilterList.Select(p => p.ContentTypeId)
-                    .All(p => p == null));
-
         }
 
         [Test]
@@ -1069,10 +1065,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             var contentTypeIdFilterList = startingQuery.BuildQuery(contentTypeIdFilter).ToList();
             Assert.IsTrue(contentTypeIdFilterList != null);
             Assert.IsTrue(contentTypeIdFilterList.Count == 4);
-            Assert.IsTrue(
-                contentTypeIdFilterList.Select(p => p.ContentTypeId)
-                    .All(p => p != null));
-
         }
 
         [Test]

--- a/Castle.DynamicLinqQueryBuilder.v3.ncrunchsolution
+++ b/Castle.DynamicLinqQueryBuilder.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>False</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/Castle.DynamicLinqQueryBuilder/BuildExpressionOptions.cs
+++ b/Castle.DynamicLinqQueryBuilder/BuildExpressionOptions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Globalization;
+
+namespace Castle.DynamicLinqQueryBuilder
+{
+    /// <summary>
+    /// Options to use when building expressions
+    /// </summary>
+    public class BuildExpressionOptions
+    {
+        /// <summary>
+        /// The <see cref="CultureInfo"/> to use when converting string representations (default InvariantCulture).
+        /// </summary>
+        public CultureInfo CultureInfo => CultureInfo.InvariantCulture;
+
+        /// <summary>
+        /// Whether <see cref="DateTime"/> types should be parsed as UTC.
+        /// </summary>
+        public bool ParseDatesAsUtc { get; set; }
+
+        /// <summary>
+        /// Whether or not to use indexed property
+        /// </summary>
+        public bool UseIndexedProperty { get; set; }
+
+        /// <summary>
+        /// The name of indexable property to use.
+        /// </summary>
+        public string IndexedPropertyName { get; set; }
+    }
+}

--- a/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
+++ b/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BuildExpressionOptions.cs" />
     <Compile Include="ColumnBuilder.cs" />
     <Compile Include="ColumnDefinition.cs" />
     <Compile Include="FilterRule.cs" />

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -46,7 +46,7 @@ namespace Castle.DynamicLinqQueryBuilder
         /// <param name="useIndexedProperty">Whether or not to use indexed property</param>
         /// <param name="indexedPropertyName">The indexable property to use</param>
         /// <returns>Filtered IQueryable</returns>
-        public static IQueryable<T> BuildQuery<T>(this IList<T> queryable, FilterRule filterRule, bool useIndexedProperty = false, string indexedPropertyName = null) 
+        public static IQueryable<T> BuildQuery<T>(this IList<T> queryable, FilterRule filterRule, bool useIndexedProperty = false, string indexedPropertyName = null)
         {
             string parsedQuery;
             return BuildQuery(queryable.AsQueryable(), filterRule, out parsedQuery, useIndexedProperty, indexedPropertyName);
@@ -63,8 +63,7 @@ namespace Castle.DynamicLinqQueryBuilder
         /// <returns>Filtered IQueryable</returns>
         public static IQueryable<T> BuildQuery<T>(this IQueryable<T> queryable, FilterRule filterRule, bool useIndexedProperty = false, string indexedPropertyName = null)
         {
-            string parsedQuery;
-            return BuildQuery(queryable, filterRule, out parsedQuery, useIndexedProperty, indexedPropertyName);
+            return BuildQuery(queryable, filterRule, out string _, useIndexedProperty, indexedPropertyName);
         }
 
         /// <summary>
@@ -80,43 +79,105 @@ namespace Castle.DynamicLinqQueryBuilder
         /// <returns>Filtered IQueryable.</returns>
         public static IQueryable<T> BuildQuery<T>(this IQueryable<T> queryable, FilterRule filterRule, out string parsedQuery, bool useIndexedProperty = false, string indexedPropertyName = null)
         {
-            if (filterRule == null)
+            return BuildQuery(queryable, filterRule, out parsedQuery, new BuildExpressionOptions { UseIndexedProperty = useIndexedProperty, IndexedPropertyName = indexedPropertyName });
+        }
+
+        /// <summary>
+        /// Gets the filtered collection after applying the provided filter rules. 
+        /// Returns the string representation for diagnostic purposes.
+        /// </summary>
+        /// <typeparam name="T">The generic type.</typeparam>
+        /// <param name="queryable">The queryable.</param>
+        /// <param name="filterRule">The filter rule.</param>
+        /// <param name="options">The options to use when building the expression</param>
+        /// <returns>Filtered IQueryable.</returns>
+        public static IQueryable<T> BuildQuery<T>(this IQueryable<T> queryable, FilterRule filterRule, BuildExpressionOptions options)
+        {
+            return BuildQuery(queryable, filterRule, out string _, options);
+        }
+
+
+        /// <summary>
+        /// Gets the filtered collection after applying the provided filter rules. 
+        /// Returns the string representation for diagnostic purposes.
+        /// </summary>
+        /// <typeparam name="T">The generic type.</typeparam>
+        /// <param name="queryable">The queryable.</param>
+        /// <param name="filterRule">The filter rule.</param>
+        /// <param name="options">The options to use when building the expression</param>
+        /// <param name="parsedQuery">The parsed query.</param>
+        /// <returns>Filtered IQueryable.</returns>
+        public static IQueryable<T> BuildQuery<T>(this IQueryable<T> queryable, FilterRule filterRule, BuildExpressionOptions options, out string parsedQuery)
+        {
+            var expression = BuildExpressionLambda<T>(filterRule, options, out parsedQuery);
+
+            if (expression == null)
             {
-                parsedQuery = "";
                 return queryable;
             }
-
-            var pe = Expression.Parameter(typeof(T), "item");
-
-            var expressionTree = BuildExpressionTree(pe, filterRule, useIndexedProperty, indexedPropertyName);
-            if (expressionTree == null)
-            {
-                parsedQuery = "";
-                return queryable;
-            }
-
-            parsedQuery = expressionTree.ToString();
 
             var whereCallExpression = Expression.Call(
                 typeof(Queryable),
                 "Where",
                 new[] { queryable.ElementType },
                 queryable.Expression,
-                Expression.Lambda<Func<T, bool>>(expressionTree, pe));
+                expression);
 
             var filteredResults = queryable.Provider.CreateQuery<T>(whereCallExpression);
 
             return filteredResults;
+        }
+
+        /// <summary>
+        /// Builds a predicate that returns whether an input test object passes the filter rule.
+        /// </summary>
+        /// <typeparam name="T">The generic type of the input object to test.</typeparam>
+        /// <param name="filterRule">The filter rule.</param>
+        /// <param name="parsedQuery">The parsed query.</param>
+        /// <param name="options">The options to use when building the expression</param>
+        /// <returns>A predicate function implementinf the filter rule</returns>
+        public static Func<T, bool> BuildPredicate<T>(this FilterRule filterRule, BuildExpressionOptions options, out string parsedQuery)
+        {
+            var expression = BuildExpressionLambda<T>(filterRule, options, out parsedQuery);
+
+            if (expression == null)
+            {
+                return _ => true;
+            }
+
+            return expression.Compile();
+        }
+
+        private static Expression<Func<T, bool>> BuildExpressionLambda<T>(FilterRule filterRule, BuildExpressionOptions options, out string parsedQuery)
+        {
+            if (filterRule == null)
+            {
+                parsedQuery = "";
+                return null;
+            }
+
+            var pe = Expression.Parameter(typeof(T), "item");
+
+            var expressionTree = BuildExpressionTree(pe, filterRule, options);
+            if (expressionTree == null)
+            {
+                parsedQuery = "";
+                return null;
+            }
+
+            parsedQuery = expressionTree.ToString();
+
+            return Expression.Lambda<Func<T, bool>>(expressionTree, pe);
 
         }
 
-        private static Expression BuildExpressionTree(ParameterExpression pe, FilterRule rule, bool useIndexedProperty = false, string indexedPropertyName = null)
+        private static Expression BuildExpressionTree(ParameterExpression pe, FilterRule rule, BuildExpressionOptions options)
         {
 
             if (rule.Rules != null && rule.Rules.Any())
             {
                 var expressions =
-                    rule.Rules.Select(childRule => BuildExpressionTree(pe, childRule, useIndexedProperty, indexedPropertyName))
+                    rule.Rules.Select(childRule => BuildExpressionTree(pe, childRule, options))
                         .Where(expression => expression != null)
                         .ToList();
 
@@ -160,9 +221,9 @@ namespace Castle.DynamicLinqQueryBuilder
                 }
 
                 Expression propertyExp = null;
-                if (useIndexedProperty)
+                if (options.UseIndexedProperty)
                 {
-                    propertyExp = Expression.Property(pe, indexedPropertyName, Expression.Constant(rule.Field));
+                    propertyExp = Expression.Property(pe, options.IndexedPropertyName, Expression.Constant(rule.Field));
                 }
                 else
                 {
@@ -174,34 +235,34 @@ namespace Castle.DynamicLinqQueryBuilder
                 switch (rule.Operator.ToLower())
                 {
                     case "in":
-                        expression = In(type, rule.Value, propertyExp);
+                        expression = In(type, rule.Value, propertyExp, options);
                         break;
                     case "not_in":
-                        expression = NotIn(type, rule.Value, propertyExp);
+                        expression = NotIn(type, rule.Value, propertyExp, options);
                         break;
                     case "equal":
-                        expression = Equals(type, rule.Value, propertyExp);
+                        expression = Equals(type, rule.Value, propertyExp, options);
                         break;
                     case "not_equal":
-                        expression = NotEquals(type, rule.Value, propertyExp);
+                        expression = NotEquals(type, rule.Value, propertyExp, options);
                         break;
                     case "between":
-                        expression = Between(type, rule.Value, propertyExp);
+                        expression = Between(type, rule.Value, propertyExp, options);
                         break;
                     case "not_between":
-                        expression = NotBetween(type, rule.Value, propertyExp);
+                        expression = NotBetween(type, rule.Value, propertyExp, options);
                         break;
                     case "less":
-                        expression = LessThan(type, rule.Value, propertyExp);
+                        expression = LessThan(type, rule.Value, propertyExp, options);
                         break;
                     case "less_or_equal":
-                        expression = LessThanOrEqual(type, rule.Value, propertyExp);
+                        expression = LessThanOrEqual(type, rule.Value, propertyExp, options);
                         break;
                     case "greater":
-                        expression = GreaterThan(type, rule.Value, propertyExp);
+                        expression = GreaterThan(type, rule.Value, propertyExp, options);
                         break;
                     case "greater_or_equal":
-                        expression = GreaterThanOrEqual(type, rule.Value, propertyExp);
+                        expression = GreaterThanOrEqual(type, rule.Value, propertyExp, options);
                         break;
                     case "begins_with":
                         expression = BeginsWith(type, rule.Value, propertyExp);
@@ -245,19 +306,19 @@ namespace Castle.DynamicLinqQueryBuilder
 
         }
 
-        private static List<ConstantExpression> GetConstants(Type type, string value, bool isCollection)
+        private static List<ConstantExpression> GetConstants(Type type, string value, bool isCollection, BuildExpressionOptions options)
         {
-            if (type == typeof (DateTime) && ParseDatesAsUtc)
+            if (type == typeof(DateTime) && (options.ParseDatesAsUtc || ParseDatesAsUtc))
             {
                 DateTime tDate;
                 if (isCollection)
                 {
                     var vals =
-                        value.Split(new[] {",", "[", "]", "\r\n"}, StringSplitOptions.RemoveEmptyEntries)
+                        value.Split(new[] { ",", "[", "]", "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
                             .Where(p => !string.IsNullOrWhiteSpace(p))
                             .Select(
                                 p =>
-                                    DateTime.TryParse(p.Trim(), CultureInfo.InvariantCulture,
+                                    DateTime.TryParse(p.Trim(), options.CultureInfo,
                                         DateTimeStyles.AdjustToUniversal, out tDate)
                                         ? (DateTime?)
                                             tDate
@@ -269,7 +330,7 @@ namespace Castle.DynamicLinqQueryBuilder
                 {
                     return new List<ConstantExpression>()
                     {
-                        Expression.Constant(DateTime.TryParse(value.Trim(), CultureInfo.InvariantCulture,
+                        Expression.Constant(DateTime.TryParse(value.Trim(), options.CultureInfo,
                             DateTimeStyles.AdjustToUniversal, out tDate)
                             ? (DateTime?)
                                 tDate
@@ -285,7 +346,7 @@ namespace Castle.DynamicLinqQueryBuilder
                     var vals =
                         value.Split(new[] { ",", "[", "]", "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
                             .Where(p => !string.IsNullOrWhiteSpace(p))
-                            .Select(p => tc.ConvertFromString(p.Trim())).Select(p =>
+                            .Select(p => tc.ConvertFromString(null, options.CultureInfo, p.Trim())).Select(p =>
                                 Expression.Constant(p, type));
                     return vals.ToList();
                 }
@@ -294,12 +355,12 @@ namespace Castle.DynamicLinqQueryBuilder
                     var tc = TypeDescriptor.GetConverter(type);
                     return new List<ConstantExpression>()
                 {
-                    Expression.Constant(tc.ConvertFromString(value.Trim()))
+                    Expression.Constant(tc.ConvertFromString(null, options.CultureInfo, value.Trim()))
                 };
                 }
             }
 
-            
+
 
         }
 
@@ -434,16 +495,16 @@ namespace Castle.DynamicLinqQueryBuilder
 
 
 
-        private static Expression NotEquals(Type type, string value, Expression propertyExp)
+        private static Expression NotEquals(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
-            return Expression.Not(Equals(type, value, propertyExp));
+            return Expression.Not(Equals(type, value, propertyExp, options));
         }
 
 
 
-        private static Expression Equals(Type type, string value, Expression propertyExp)
+        private static Expression Equals(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
-            Expression someValue = GetConstants(type, value, false).First();
+            Expression someValue = GetConstants(type, value, false, options).First();
 
             Expression exOut;
             if (type == typeof(string))
@@ -451,7 +512,7 @@ namespace Castle.DynamicLinqQueryBuilder
                 var nullCheck = GetNullCheckExpression(propertyExp);
 
                 exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
-                someValue = Expression.Call(someValue, typeof (string).GetMethod("ToLower", Type.EmptyTypes));
+                someValue = Expression.Call(someValue, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
                 exOut = Expression.AndAlso(nullCheck, Expression.Equal(exOut, someValue));
             }
             else
@@ -464,9 +525,9 @@ namespace Castle.DynamicLinqQueryBuilder
 
         }
 
-        private static Expression LessThan(Type type, string value, Expression propertyExp)
+        private static Expression LessThan(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
-            var someValue = GetConstants(type, value, false).First();
+            var someValue = GetConstants(type, value, false, options).First();
 
             Expression exOut = Expression.LessThan(propertyExp, Expression.Convert(someValue, propertyExp.Type));
 
@@ -476,9 +537,9 @@ namespace Castle.DynamicLinqQueryBuilder
 
         }
 
-        private static Expression LessThanOrEqual(Type type, string value, Expression propertyExp)
+        private static Expression LessThanOrEqual(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
-            var someValue = GetConstants(type, value, false).First();
+            var someValue = GetConstants(type, value, false, options).First();
 
             Expression exOut = Expression.LessThanOrEqual(propertyExp, Expression.Convert(someValue, propertyExp.Type));
 
@@ -488,10 +549,10 @@ namespace Castle.DynamicLinqQueryBuilder
 
         }
 
-        private static Expression GreaterThan(Type type, string value, Expression propertyExp)
+        private static Expression GreaterThan(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
 
-            var someValue = GetConstants(type, value, false).First();
+            var someValue = GetConstants(type, value, false, options).First();
 
 
 
@@ -503,9 +564,9 @@ namespace Castle.DynamicLinqQueryBuilder
 
         }
 
-        private static Expression GreaterThanOrEqual(Type type, string value, Expression propertyExp)
+        private static Expression GreaterThanOrEqual(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
-            var someValue = GetConstants(type, value, false).First();
+            var someValue = GetConstants(type, value, false, options).First();
 
             Expression exOut = Expression.GreaterThanOrEqual(propertyExp, Expression.Convert(someValue, propertyExp.Type));
 
@@ -515,9 +576,9 @@ namespace Castle.DynamicLinqQueryBuilder
 
         }
 
-        private static Expression Between(Type type, string value, Expression propertyExp)
+        private static Expression Between(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
-            var someValue = GetConstants(type, value, true);
+            var someValue = GetConstants(type, value, true, options);
 
 
             Expression exBelow = Expression.GreaterThanOrEqual(propertyExp, Expression.Convert(someValue[0], propertyExp.Type));
@@ -528,16 +589,16 @@ namespace Castle.DynamicLinqQueryBuilder
 
         }
 
-        private static Expression NotBetween(Type type, string value, Expression propertyExp)
+        private static Expression NotBetween(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
-            return Expression.Not(Between(type, value, propertyExp));
+            return Expression.Not(Between(type, value, propertyExp, options));
         }
 
-        private static Expression In(Type type, string value, Expression propertyExp)
+        private static Expression In(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
 
 
-            var someValues = GetConstants(type, value, true);
+            var someValues = GetConstants(type, value, true, options);
 
             var nullCheck = GetNullCheckExpression(propertyExp);
 
@@ -623,9 +684,9 @@ namespace Castle.DynamicLinqQueryBuilder
 
         }
 
-        private static Expression NotIn(Type type, string value, Expression propertyExp)
+        private static Expression NotIn(Type type, string value, Expression propertyExp, BuildExpressionOptions options)
         {
-            return Expression.Not(In(type, value, propertyExp));
+            return Expression.Not(In(type, value, propertyExp, options));
         }
 
         #endregion

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -79,7 +79,7 @@ namespace Castle.DynamicLinqQueryBuilder
         /// <returns>Filtered IQueryable.</returns>
         public static IQueryable<T> BuildQuery<T>(this IQueryable<T> queryable, FilterRule filterRule, out string parsedQuery, bool useIndexedProperty = false, string indexedPropertyName = null)
         {
-            return BuildQuery(queryable, filterRule, out parsedQuery, new BuildExpressionOptions { UseIndexedProperty = useIndexedProperty, IndexedPropertyName = indexedPropertyName });
+            return BuildQuery(queryable, filterRule, new BuildExpressionOptions { UseIndexedProperty = useIndexedProperty, IndexedPropertyName = indexedPropertyName }, out parsedQuery);
         }
 
         /// <summary>
@@ -93,9 +93,8 @@ namespace Castle.DynamicLinqQueryBuilder
         /// <returns>Filtered IQueryable.</returns>
         public static IQueryable<T> BuildQuery<T>(this IQueryable<T> queryable, FilterRule filterRule, BuildExpressionOptions options)
         {
-            return BuildQuery(queryable, filterRule, out string _, options);
+            return BuildQuery(queryable, filterRule, options, out string _);
         }
-
 
         /// <summary>
         /// Gets the filtered collection after applying the provided filter rules. 
@@ -133,9 +132,21 @@ namespace Castle.DynamicLinqQueryBuilder
         /// </summary>
         /// <typeparam name="T">The generic type of the input object to test.</typeparam>
         /// <param name="filterRule">The filter rule.</param>
+        /// <param name="options">The options to use when building the expression</param>
+        /// <returns>A predicate function implementing the filter rule</returns>
+        public static Func<T, bool> BuildPredicate<T>(this FilterRule filterRule, BuildExpressionOptions options)
+        {
+            return BuildPredicate<T>(filterRule, options, out string _);
+        }
+
+        /// <summary>
+        /// Builds a predicate that returns whether an input test object passes the filter rule.
+        /// </summary>
+        /// <typeparam name="T">The generic type of the input object to test.</typeparam>
+        /// <param name="filterRule">The filter rule.</param>
         /// <param name="parsedQuery">The parsed query.</param>
         /// <param name="options">The options to use when building the expression</param>
-        /// <returns>A predicate function implementinf the filter rule</returns>
+        /// <returns>A predicate function implementing the filter rule</returns>
         public static Func<T, bool> BuildPredicate<T>(this FilterRule filterRule, BuildExpressionOptions options, out string parsedQuery)
         {
             var expression = BuildExpressionLambda<T>(filterRule, options, out parsedQuery);
@@ -148,7 +159,15 @@ namespace Castle.DynamicLinqQueryBuilder
             return expression.Compile();
         }
 
-        private static Expression<Func<T, bool>> BuildExpressionLambda<T>(FilterRule filterRule, BuildExpressionOptions options, out string parsedQuery)
+        /// <summary>
+        /// Builds an expression lambda for the filter rule.
+        /// </summary>
+        /// <typeparam name="T">The generic type of the input object to test.</typeparam>
+        /// <param name="filterRule">The filter rule.</param>
+        /// <param name="parsedQuery">The parsed query.</param>
+        /// <param name="options">The options to use when building the expression</param>
+        /// <returns>An expression lambda that implements the filter rule</returns>
+        public static Expression<Func<T, bool>> BuildExpressionLambda<T>(this FilterRule filterRule, BuildExpressionOptions options, out string parsedQuery)
         {
             if (filterRule == null)
             {

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -63,7 +63,8 @@ namespace Castle.DynamicLinqQueryBuilder
         /// <returns>Filtered IQueryable</returns>
         public static IQueryable<T> BuildQuery<T>(this IQueryable<T> queryable, FilterRule filterRule, bool useIndexedProperty = false, string indexedPropertyName = null)
         {
-            return BuildQuery(queryable, filterRule, out string _, useIndexedProperty, indexedPropertyName);
+            string parsedQuery;
+            return BuildQuery(queryable, filterRule, out parsedQuery, useIndexedProperty, indexedPropertyName);
         }
 
         /// <summary>
@@ -93,7 +94,8 @@ namespace Castle.DynamicLinqQueryBuilder
         /// <returns>Filtered IQueryable.</returns>
         public static IQueryable<T> BuildQuery<T>(this IQueryable<T> queryable, FilterRule filterRule, BuildExpressionOptions options)
         {
-            return BuildQuery(queryable, filterRule, options, out string _);
+            string parsedQuery;
+            return BuildQuery(queryable, filterRule, options, out parsedQuery);
         }
 
         /// <summary>
@@ -136,7 +138,8 @@ namespace Castle.DynamicLinqQueryBuilder
         /// <returns>A predicate function implementing the filter rule</returns>
         public static Func<T, bool> BuildPredicate<T>(this FilterRule filterRule, BuildExpressionOptions options)
         {
-            return BuildPredicate<T>(filterRule, options, out string _);
+            string parsedQuery;
+            return BuildPredicate<T>(filterRule, options, out parsedQuery);
         }
 
         /// <summary>


### PR DESCRIPTION
Hi,

Your library saved me a lot of time, thank you. 
My main issue with it is that the expression tree is created every time BuildQuery is called. This is quite wasteful in cases (such as mine) where the filter rule is part of the application configuration and meant to be reused many (many) times.
Fortunately it was quite easy to refactor the code calling BuildExpressionTree to expose the expression so it can be saved for later use.
I added two extension methods for FilterRule to QueryBuilder:

_BuildExpressionLambda_ which returns the expression.
_BuildPredicate_ which returns a compiled lambda function.

In addition when I forked your code I found the culture for the date conversions could not be easily set which caused all date unit tests to fail as they were using 'MM/dd/yyyy' and my default culture uses 'dd/MM/yyyy'. I created a BuildExpressionOptions class to host all the configuration options instead of adding even more optional parameters. One of the options is a culture info class.
This should be mostly backward compatible with your code.

I hope you find this code a useful addition to your library and can merge it without much problem. If you have questions or require changes please contact me.

Kind Regards,
Eli Algranti