### PR TITLE
Updated compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Features (v1.0.5)
   * is not empty
   * is null
   * is not null
-* Compatible with jQuery-QueryBuilder (see samples for an example)
+* Compatible with [jQuery QueryBuilder](https://querybuilder.js.org) (see samples for an example)
 
 Installation
 --


### PR DESCRIPTION
When searching for best option to get all FilterRules for jQuery QueryBuilder, I cannot find this NuGet package nor cannot find it on Google. Upon further search, the problem is that jQuery QueryBuilder on the description has a dash on it, so I removed it and added a link so that this tool will show on google search results when someone will look for dynamic linq query builder just like I did.