### PR TITLE
In Query is not working.

### DIFF
--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -285,7 +285,7 @@ namespace Castle.DynamicLinqQueryBuilder
                     var vals =
                         value.Split(new[] { ",", "[", "]", "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
                             .Where(p => !string.IsNullOrWhiteSpace(p))
-                            .Select(p => tc.ConvertFromString(p.Trim())).Select(p =>
+                            .Select(p => tc.ConvertFromString(p.Trim().ToLower())).Select(p =>
                                 Expression.Constant(p, type));
                     return vals.ToList();
                 }


### PR DESCRIPTION
The "In" query is not working. Upon debugging, I found out the following issue:

These code:

exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
exOut = Expression.Equal(exOut, someValues.First());

is comparing to ToLower which is not the case if the variable someValues has all uppercase. So either we remove the ToLower here or change the GetConstants method to return also all lower case so that it will have both a match.

I discovered the issue when I am querying a string with all uppercase. It always return zero results. So upon changing the GetConstants method specifically on this line:

if (isCollection)
                {
                    var tc = TypeDescriptor.GetConverter(type);
                    var vals =
                        value.Split(new[] { ",", "[", "]", "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
                            .Where(p => !string.IsNullOrWhiteSpace(p))
                            .Select(p => tc.ConvertFromString(p.Trim().ToLower())).Select(p =>
                                Expression.Constant(p, type));
                    return vals.ToList();
                }

the error was fixed.