### PR TITLE
"In Query" is not working.

### DIFF
--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -576,14 +576,16 @@ namespace Castle.DynamicLinqQueryBuilder
                     {
 
                         exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
-                        exOut = Expression.Equal(exOut, Expression.Convert(someValues[0], propertyExp.Type));
+                        var somevalue = Expression.Call(someValues[0], typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+                        exOut = Expression.Equal(exOut, somevalue);
                         var counter = 1;
                         while (counter < someValues.Count)
                         {
+                            var nextvalue = Expression.Call(someValues[counter], typeof(string).GetMethod("ToLower", Type.EmptyTypes));
                             exOut = Expression.Or(exOut,
                                 Expression.Equal(
                                     Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes)),
-                                    Expression.Convert(someValues[counter], propertyExp.Type)));
+                                    nextvalue));
                             counter++;
                         }
                     }
@@ -608,7 +610,8 @@ namespace Castle.DynamicLinqQueryBuilder
                     {
 
                         exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
-                        exOut = Expression.Equal(exOut, someValues.First());
+                        var somevalue = Expression.Call(someValues.First(), typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+                        exOut = Expression.Equal(exOut, somevalue);
                     }
                     else
                     {


### PR DESCRIPTION
This is an update on PR related to this previous request:

https://github.com/castle-it/dynamic-linq-query-builder/pull/31

As suggested by @tghamm, the tolower comparisons for strings are handled in each individual operator type. So I re-adjust in on static Expression "In" method.

I discovered the issue when I am querying a string with all uppercase. It always return zero results.