### PR TITLE
Corrected Test Method for Integer Comparison

### DIFF
--- a/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
@@ -1009,7 +1009,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             Assert.IsTrue(contentTypeIdFilterList.Count == 0);
             Assert.IsTrue(
                 contentTypeIdFilterList.Select(p => p.ContentTypeId)
-                    .All(p => p == null));
+                    .All(p => p == 0));
 
         }
 
@@ -1067,7 +1067,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             Assert.IsTrue(contentTypeIdFilterList.Count == 4);
             Assert.IsTrue(
                 contentTypeIdFilterList.Select(p => p.ContentTypeId)
-                    .All(p => p != null));
+                    .All(p => p != 0));
 
         }
 


### PR DESCRIPTION
Correction for comparison of integer which you can only compare with values and not on "null".

This will result as warning message in Visual Studio which specifies:

The result of the expression is always 'false' since a value of type 'int' is never equal to 'null' of type 'int?'

This will also generate an AppVeyor message error when compiled.