### PR TITLE
AppVeyor Build Failure

### DIFF
--- a/Castle.DynamicLinqQueryBuilder.Tests/ExceptionAssert.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/ExceptionAssert.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             {
                 exceptionThrown = true;
             }
-            catch (Exception ex)
+            catch (Exception)
             {
 
             }


### PR DESCRIPTION
This generates AppVeyor build error message specifically:

The variable 'ex' is declared but never used ExceptionAssert.cs at line 21.

I corrected it by not declaring any variable name at all.