### PR TITLE
Adds two operators : is_null_or_empty and is_not_null_and_not_empty.

### DIFF
--- a/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
+++ b/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
@@ -12,7 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.4.1</Version>
+    <Version>1.1.4.2</Version>
     <Authors>Grant Hamm</Authors>
     <Company>Castle Worldwide, Inc</Company>
     <Product>Dynamic Linq Query Builder</Product>
@@ -23,9 +23,9 @@
     <RepositoryUrl>https://github.com/castle-it/dynamic-linq-query-builder/</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>jquery-query-builder generic query generator linq javascript</PackageTags>
-    <PackageReleaseNotes>Adds two operators : is_null_or_empty and is_not_null_and_not_empty.</PackageReleaseNotes>
-    <AssemblyVersion>1.1.4.1</AssemblyVersion>
-    <FileVersion>1.1.4.1</FileVersion>
+    <PackageReleaseNotes>Handling one new type in order to query 'MMdd' formatted dates (anniversarydate)</PackageReleaseNotes>
+    <AssemblyVersion>1.1.4.2</AssemblyVersion>
+    <FileVersion>1.1.4.2</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
+++ b/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
@@ -12,7 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.4</Version>
+    <Version>1.1.4.1</Version>
     <Authors>Grant Hamm</Authors>
     <Company>Castle Worldwide, Inc</Company>
     <Product>Dynamic Linq Query Builder</Product>
@@ -23,7 +23,9 @@
     <RepositoryUrl>https://github.com/castle-it/dynamic-linq-query-builder/</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>jquery-query-builder generic query generator linq javascript</PackageTags>
-    <PackageReleaseNotes>Adds support for nested collections.</PackageReleaseNotes>
+    <PackageReleaseNotes>Adds two operators : is_null_or_empty and is_not_null_and_not_empty.</PackageReleaseNotes>
+    <AssemblyVersion>1.1.4.1</AssemblyVersion>
+    <FileVersion>1.1.4.1</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
+++ b/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
@@ -12,7 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.4.2</Version>
+    <Version>1.1.4.3</Version>
     <Authors>Grant Hamm</Authors>
     <Company>Castle Worldwide, Inc</Company>
     <Product>Dynamic Linq Query Builder</Product>
@@ -23,9 +23,9 @@
     <RepositoryUrl>https://github.com/castle-it/dynamic-linq-query-builder/</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>jquery-query-builder generic query generator linq javascript</PackageTags>
-    <PackageReleaseNotes>Handling one new type in order to query 'MMdd' formatted dates (anniversarydate)</PackageReleaseNotes>
-    <AssemblyVersion>1.1.4.2</AssemblyVersion>
-    <FileVersion>1.1.4.2</FileVersion>
+    <PackageReleaseNotes>Handling nullable DateTime for new type anniversarydate</PackageReleaseNotes>
+    <AssemblyVersion>1.1.4.3</AssemblyVersion>
+    <FileVersion>1.1.4.3</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -366,6 +366,12 @@ namespace Castle.DynamicLinqQueryBuilder
                 case "is_not_null":
                     expression = IsNotNull(propertyExp);
                     break;
+                case "is_null_or_empty":
+                    expression = IsNullOrEmpty(propertyExp);
+                    break;
+                case "is_not_null_and_not_empty":
+                    expression = IsNotNullAndNotEmpty(propertyExp);
+                    break;
                 default:
                     throw new Exception($"Unknown expression operator: {rule.Operator}");
             }
@@ -560,6 +566,16 @@ namespace Castle.DynamicLinqQueryBuilder
         private static Expression IsNotEmpty(Expression propertyExp)
         {
             return Expression.Not(IsEmpty(propertyExp));
+        }
+
+        private static Expression IsNullOrEmpty(Expression propertyExp)
+        {
+            return Expression.Or(IsEmpty(propertyExp), IsNull(propertyExp));
+        }
+
+        private static Expression IsNotNullAndNotEmpty(Expression propertyExp)
+        {
+            return Expression.Not(IsNullOrEmpty(propertyExp));
         }
 
         private static Expression Contains(Type type, object value, Expression propertyExp)


### PR DESCRIPTION
Hi, thank you very much for your great work on this amazing library !

I've noticed through SQL Profiler that the group of two rules ["string is_not_null" and "string is_not_empty"] was not returning good results .

Hence, I've added 2 operators in order to handle this case (and its opposite "is_null_or_empty").

Note : these operators should be only appliable on type "String".