### PR TITLE
Change Or/And for OrElse/AndAlso to decrease sql cpu usage

### DIFF
--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -210,8 +210,8 @@ namespace Castle.DynamicLinqQueryBuilder
                 while (counter < expressions.Count)
                 {
                     expressionTree = rule.Condition.ToLower() == "or"
-                        ? Expression.Or(expressionTree, expressions[counter])
-                        : Expression.And(expressionTree, expressions[counter]);
+                        ? Expression.OrElse(expressionTree, expressions[counter])
+                        : Expression.AndAlso(expressionTree, expressions[counter]);
                     counter++;
                 }
 


### PR DESCRIPTION
Using Or/And againt Sql Server parses as a bitwise comperer, thus forcing Sql Server to evaluate the value of a condition first before applying the bitwise operator | &, that puts more strain on CPU, because is not letting Sql use it's native way to partition results, changing that to AndAlso/OrElse parses in a native way Sql Server expects a where query. For example:

----Using Or/And on two rules, where one searches for a int value and the second one for a contains in a text parses to something similar to:
WHERE (CASE
    WHEN [item].[SomeId] = 1055
    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
END & CASE
    WHEN [item].[SomeName] IS NOT NULL AND (CHARINDEX(N'xyz', LOWER([item].[SomeName])) > 0)
    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
END) = 1

--While the same example using AndAlso/OrElse translates to something similar to this:
WHERE ([item].[SomeId] = 1055 AND  ([item].[SomeName] IS NOT NULL AND (CHARINDEX(N'xyz', LOWER([item].[SomeName])) > 0)))
Avoiding with that a computation in Sql Server that comes from using the case statements