### PR TITLE
Added string conversions before using string methods.

### DIFF
--- a/Castle.DynamicLinqQueryBuilder.Tests/JsonNetFilterRuleTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/JsonNetFilterRuleTests.cs
@@ -544,6 +544,55 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             Assert.IsTrue(
                 nullableWrappedStatFilterList.Select(p => p.PossiblyEmptyStatValue)
                     .All(p => p == 1.112));
+
+            var firstGuid = StartingQuery.First().ContentTypeGuid.ToString();
+            //expect one entry to match for a Guid Comparison
+            var contentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "string",
+                        Value = new[] { firstGuid, firstGuid }
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count == 1);
+
+
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "string",
+                        Value = new[] { firstGuid }
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
+
         }
 
         [Test]
@@ -1246,6 +1295,52 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                 longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
                     .All(p => p.Contains("something interesting")));
 
+            //expect at least one entry to match for a Guid Comparison
+            var contentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "contains",
+                        Type = "string",
+                        Value = StartingQuery.First().ContentTypeGuid.ToString().Substring(0,5)
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count >= 1);
+
+
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "contains",
+                        Type = "string",
+                        Value = StartingQuery.First().ContentTypeGuid.ToString().Substring(0, 5)
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
         }
 
         [Test]
@@ -1336,6 +1431,54 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                 longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
                     .All(p => p.EndsWith("about this text")));
 
+            var fristGuid = StartingQuery.First().ContentTypeGuid.ToString();
+            //expect at least one entry to match for a Guid Comparison
+            var contentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "ends_with",
+                        Type = "string",
+                        Value = fristGuid.Substring(fristGuid.Length - 5)
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count >= 1);
+
+
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "ends_with",
+                        Type = "string",
+                        Value = fristGuid.Substring(fristGuid.Length - 5)
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
+
         }
 
         [Test]
@@ -1395,6 +1538,54 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             Assert.IsTrue(
                 longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
                     .All(p => p.StartsWith("there is something")));
+
+            var firstGuid = StartingQuery.First().ContentTypeGuid.ToString();
+            //expect at least one entry to match for a Guid Comparison
+            var contentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "begins_with",
+                        Type = "string",
+                        Value = firstGuid.Substring(0,5)
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count >= 1);
+
+
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "begins_with",
+                        Type = "string",
+                        Value = firstGuid.Substring(0,5)
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
 
         }
 
@@ -1457,8 +1648,52 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             Assert.IsTrue(nullableContentIdFilteredList.Count == 1);
             Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId == 1));
 
+            //expect one entry to match for a Guid Comparison
+            var contentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "string",
+                        Value = StartingQuery.First().ContentTypeGuid.ToString()
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count == 1);
 
 
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "string",
+                        Value = StartingQuery.First().ContentTypeGuid.ToString()
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
 
             //expect 3 entries to match for a case-insensitive string comparison
             var longerTextToFilterFilter = new JsonNetFilterRule

--- a/Castle.DynamicLinqQueryBuilder.Tests/QueryBuilderFilterRuleTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/QueryBuilderFilterRuleTests.cs
@@ -502,6 +502,54 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             Assert.IsTrue(multipleWithBlankList != null);
             Assert.IsTrue(multipleWithBlankList.Count == 4);
             Assert.IsTrue(multipleWithBlankList.All(p => p.StrList.Contains("") || p.StrList.Contains("Str2")));
+
+            var firstGuid = StartingQuery.First().ContentTypeGuid.ToString();
+            //expect one entry to match for a Guid Comparison
+            var contentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "string",
+                        Value = new[] { firstGuid, firstGuid }
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count == 1);
+
+
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "string",
+                        Value = new[] { firstGuid }
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
         }
 
         [Test]
@@ -1188,6 +1236,52 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                 longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
                     .All(p => p.Contains("something interesting")));
 
+            //expect at least one entry to match for a Guid Comparison
+            var contentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "contains",
+                        Type = "string",
+                        Value = new[] { StartingQuery.First().ContentTypeGuid.ToString().Substring(0,5) }
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count >= 1);
+
+
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "contains",
+                        Type = "string",
+                        Value = new[] { StartingQuery.First().ContentTypeGuid.ToString().Substring(0, 5) }
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
         }
 
         [Test]
@@ -1278,6 +1372,53 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
                 longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
                     .All(p => p.EndsWith("about this text")));
 
+            var fristGuid = StartingQuery.First().ContentTypeGuid.ToString();
+            //expect at least one entry to match for a Guid Comparison
+            var contentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "ends_with",
+                        Type = "string",
+                        Value = new[] { fristGuid.Substring(fristGuid.Length - 5) }
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count >= 1);
+
+
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "ends_with",
+                        Type = "string",
+                        Value = new[] { fristGuid.Substring(fristGuid.Length - 5) }
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
         }
 
         [Test]
@@ -1337,6 +1478,54 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             Assert.IsTrue(
                 longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
                     .All(p => p.StartsWith("there is something")));
+
+            var firstGuid = StartingQuery.First().ContentTypeGuid.ToString();
+            //expect at least one entry to match for a Guid Comparison
+            var contentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "begins_with",
+                        Type = "string",
+                        Value = new[] { firstGuid.Substring(0,5) }
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count >= 1);
+
+
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "begins_with",
+                        Type = "string",
+                        Value = new[] { firstGuid.Substring(0,5) }
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
 
         }
 
@@ -1399,8 +1588,52 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             Assert.IsTrue(nullableContentIdFilteredList.Count == 1);
             Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId == 1));
 
+            //expect one entry to match for a Guid Comparison
+            var contentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeGuid",
+                        Id = "ContentTypeGuid",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "string",
+                        Value = new[] { StartingQuery.First().ContentTypeGuid.ToString() }
+                    }
+                }
+            };
+
+            var contentGuidFilteredList = StartingQuery.BuildQuery(contentGuidFilter).ToList();
+            Assert.IsTrue(contentGuidFilteredList != null);
+            Assert.IsTrue(contentGuidFilteredList.Count == 1);
 
 
+            //expect no entry to match for a Guid Comparison against a null nullable Id
+            var nullableContentGuidFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeGuid",
+                        Id = "NullableContentTypeGuid",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "string",
+                        Value = new[] { StartingQuery.First().ContentTypeGuid.ToString() }
+                    }
+                }
+            };
+
+            var nullableContentGuidFilteredList = StartingQuery.BuildQuery(nullableContentGuidFilter).ToList();
+            Assert.IsTrue(nullableContentGuidFilteredList != null);
+            Assert.IsTrue(nullableContentGuidFilteredList.Count == 0);
 
             //expect 3 entries to match for a case-insensitive string comparison
             var longerTextToFilterFilter = new QueryBuilderFilterRule

--- a/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
@@ -20,6 +20,8 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
         {
             public int ContentTypeId { get; set; }
             public int? NullableContentTypeId { get; set; }
+            public Guid ContentTypeGuid { get; set; }
+            public Guid? NullableContentTypeGuid { get; set; }
             public List<int> Enemies { get; set; }
             public List<string> Flags { get; set; }
             public string ContentTypeName { get; set; }
@@ -45,6 +47,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             var entry1 = new ExpressionTreeBuilderTestClass()
             {
                 ContentTypeId = 1,
+                ContentTypeGuid = Guid.NewGuid(),
                 ContentTypeName = "Multiple-Choice",
                 Enemies = new List<int>(),
                 Flags = new List<string>(),
@@ -74,6 +77,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             var entry1 = new ExpressionTreeBuilderTestClass()
             {
                 ContentTypeId = 1,
+                ContentTypeGuid = Guid.NewGuid(),
                 ContentTypeName = "Multiple-Choice",
                 Enemies = new List<int>(),
                 Flags = new List<string>(),
@@ -96,6 +100,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             var entry2 = new ExpressionTreeBuilderTestClass()
             {
                 ContentTypeId = 2,
+                ContentTypeGuid = Guid.NewGuid(),
                 ContentTypeName = "Multiple-Select",
                 Enemies = null,
                 Flags = null,
@@ -118,6 +123,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             var entry3 = new ExpressionTreeBuilderTestClass()
             {
                 ContentTypeId = 3,
+                ContentTypeGuid = Guid.NewGuid(),
                 ContentTypeName = "Drag-and-Drop Item",
                 Enemies = new List<int>() { 3391, 3985 },
                 Flags = new List<string>() { "this is a flag" },
@@ -140,6 +146,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             var entry4 = new ExpressionTreeBuilderTestClass()
             {
                 ContentTypeId = 1,
+                ContentTypeGuid = Guid.NewGuid(),
                 ContentTypeName = "Multiple-Choice",
                 Enemies = new List<int>(),
                 Flags = new List<string>() { "THIS IS A FLAG" },

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -580,9 +580,9 @@ namespace Castle.DynamicLinqQueryBuilder
 
             var nullCheck = GetNullCheckExpression(propertyExp);
 
-            var method = propertyExp.Type.GetMethod("Contains", new[] { type });
-
-            Expression exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+            var propertyExpString = Expression.Call(propertyExp, propertyExp.Type.GetMethod("ToString", Type.EmptyTypes));
+            var method = propertyExpString.Type.GetMethod("Contains", new[] { type });
+            Expression exOut = Expression.Call(propertyExpString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
 
             exOut = Expression.AndAlso(nullCheck, Expression.Call(exOut, method, someValue));
 
@@ -602,9 +602,9 @@ namespace Castle.DynamicLinqQueryBuilder
 
             var nullCheck = GetNullCheckExpression(propertyExp);
 
-            var method = propertyExp.Type.GetMethod("EndsWith", new[] { type });
-
-            Expression exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+            var propertyExpString = Expression.Call(propertyExp, propertyExp.Type.GetMethod("ToString", Type.EmptyTypes));
+            var method = propertyExpString.Type.GetMethod("EndsWith", new[] { type });
+            Expression exOut = Expression.Call(propertyExpString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
 
             exOut = Expression.AndAlso(nullCheck, Expression.Call(exOut, method, someValue));
 
@@ -624,9 +624,9 @@ namespace Castle.DynamicLinqQueryBuilder
 
             var nullCheck = GetNullCheckExpression(propertyExp);
 
-            var method = propertyExp.Type.GetMethod("StartsWith", new[] { type });
-
-            Expression exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+            var propertyExpString = Expression.Call(propertyExp, propertyExp.Type.GetMethod("ToString", Type.EmptyTypes));
+            var method = propertyExpString.Type.GetMethod("StartsWith", new[] { type });
+            Expression exOut = Expression.Call(propertyExpString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
 
             exOut = Expression.AndAlso(nullCheck, Expression.Call(exOut, method, someValue));
 
@@ -656,8 +656,11 @@ namespace Castle.DynamicLinqQueryBuilder
             {
                 var nullCheck = GetNullCheckExpression(propertyExp);
 
-                exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
-                someValue = Expression.Call(someValue, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+                var propertyExpString = Expression.Call(propertyExp, propertyExp.Type.GetMethod("ToString", Type.EmptyTypes));
+                exOut = Expression.Call(propertyExpString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+
+                var someValueString = Expression.Call(someValue, someValue.Type.GetMethod("ToString", Type.EmptyTypes));
+                someValue = Expression.Call(someValueString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
                 exOut = Expression.AndAlso(nullCheck, Expression.Equal(exOut, someValue));
             }
             else
@@ -779,16 +782,22 @@ namespace Castle.DynamicLinqQueryBuilder
                     if (type == typeof(string))
                     {
 
-                        exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
-                        var somevalue = Expression.Call(someValues[0], typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+                        var propertyExpString = Expression.Call(propertyExp, propertyExp.Type.GetMethod("ToString", Type.EmptyTypes));
+                        exOut = Expression.Call(propertyExpString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+
+                        var someValueString = Expression.Call(someValues[0], someValues[0].Type.GetMethod("ToString", Type.EmptyTypes));
+                        var somevalue = Expression.Call(someValueString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
                         exOut = Expression.Equal(exOut, somevalue);
                         var counter = 1;
                         while (counter < someValues.Count)
                         {
-                            var nextvalue = Expression.Call(someValues[counter], typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+
+                            var nextvalueString = Expression.Call(someValues[counter], someValues[counter].Type.GetMethod("ToString", Type.EmptyTypes));
+                            var nextvalue = Expression.Call(nextvalueString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+
                             exOut = Expression.Or(exOut,
                                 Expression.Equal(
-                                    Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes)),
+                                    Expression.Call(propertyExpString, typeof(string).GetMethod("ToLower", Type.EmptyTypes)),
                                     nextvalue));
                             counter++;
                         }
@@ -812,9 +821,11 @@ namespace Castle.DynamicLinqQueryBuilder
                 {
                     if (type == typeof(string))
                     {
+                        var propertyExpString = Expression.Call(propertyExp, propertyExp.Type.GetMethod("ToString", Type.EmptyTypes));
+                        exOut = Expression.Call(propertyExpString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
 
-                        exOut = Expression.Call(propertyExp, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
-                        var somevalue = Expression.Call(someValues.First(), typeof(string).GetMethod("ToLower", Type.EmptyTypes));
+                        var someValueString = Expression.Call(someValues.First(), someValues.First().Type.GetMethod("ToString", Type.EmptyTypes));
+                        var somevalue = Expression.Call(someValueString, typeof(string).GetMethod("ToLower", Type.EmptyTypes));
                         exOut = Expression.Equal(exOut, somevalue);
                     }
                     else


### PR DESCRIPTION
I need to use this library against C# models with Guid types. My queries are looking up related data using Guid navigation properties. I don't really need to use the "." (dot) navigation rules because I don't want to look up the related objects in the database just to query, I am fine querying against the navigation property itself.

I am just fine with treating the Guid properties as strings for the purposes of comparing them. HOWEVER, currently when using string operators such as "Equals" or even "In", this library is calling "ToLower" assuming the properties are strings. Since Guid does not have a "ToLower" I get an exception.

This PR is to add an expression step to call "ToString" before calling any string related methods (such as "ToLower" or "Contains"). All tests pass and I have added Guid (and nullable Guid) fields to the test objects so that I can prove that the "ToString" method call works. 

There is some risk that some type will be used that does not have a "ToString" method but I assume it would also not have a "ToLower"/"Contains" method and would throw an exception anyway. 