### PR TITLE
Fixed issue with System.Text.Json

### DIFF
--- a/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Tests.cs
@@ -38,7 +38,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
 
         }
 
-        internal static List<ExpressionTreeBuilderTestClass> GetDateExpressionTreeData()
+        public static List<ExpressionTreeBuilderTestClass> GetDateExpressionTreeData()
         {
             var tData = new List<ExpressionTreeBuilderTestClass>();
 
@@ -67,7 +67,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests
             return tData;
         }
 
-        internal static List<ExpressionTreeBuilderTestClass> GetExpressionTreeData()
+        public static List<ExpressionTreeBuilderTestClass> GetExpressionTreeData()
         {
             var tData = new List<ExpressionTreeBuilderTestClass>();
 

--- a/Castle.DynamicLinqQueryBuilder.Tests31/Castle.DynamicLinqQueryBuilder.Tests31.csproj
+++ b/Castle.DynamicLinqQueryBuilder.Tests31/Castle.DynamicLinqQueryBuilder.Tests31.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Castle.DynamicLinqQueryBuilder.Tests\Castle.DynamicLinqQueryBuilder.Tests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Castle.DynamicLinqQueryBuilder.Tests31/SystemTextJsonTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests31/SystemTextJsonTests.cs
@@ -42,17 +42,121 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
         }
         #endregion
 
+        #region JsonSerializer
+        private SystemTextJsonFilterRule passThroughSerializer(SystemTextJsonFilterRule rule)
+        {
+            return JsonSerializer.Deserialize<SystemTextJsonFilterRule>(JsonSerializer.Serialize(rule));
+        }
+        #endregion
+
         #region Expression Tree Builder
+        [Test]
+        public void DateHandling()
+        {
+            QueryBuilder.ParseDatesAsUtc = true;
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "date",
+                        Value = "2/23/2016"
+                    }
+                }
+            };
+            var queryable = StartingDateQuery.BuildQuery<Tests.Tests.ExpressionTreeBuilderTestClass>(contentIdFilter);
+            var contentIdFilteredList = queryable.ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 1);
+
+            contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "date",
+                        Value = ""
+                    }
+                }
+            };
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                var contentIdFilteredListNull1 = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            });
+
+
+            contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "DateList",
+                        Id = "DateList",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "date",
+                        Value = "2/23/2016"
+                    }
+                }
+            };
+            queryable = StartingDateQuery.BuildQuery(contentIdFilter);
+            var contentIdFilteredList2 = queryable.ToList();
+            Assert.IsTrue(contentIdFilteredList2 != null);
+            Assert.IsTrue(contentIdFilteredList2.Count == 1);
+
+            contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "DateList",
+                        Id = "DateList",
+                        Input = "NA",
+                        Operator = "between",
+                        Type = "date",
+                        Value = ""
+                    }
+                }
+            };
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                var contentIdFilteredListNull2 = StartingDateQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            QueryBuilder.ParseDatesAsUtc = false;
+        }
+
         [Test]
         public void InClause()
         {
             //expect two entries to match for an integer comparison
-            var contentIdFilter = new JsonNetFilterRule
+            var contentIdFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "ContentTypeId",
@@ -64,9 +168,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            contentIdFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(contentIdFilter));
-
             var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
             Assert.IsTrue(contentIdFilteredList != null);
             Assert.IsTrue(contentIdFilteredList.Count == 3);
@@ -81,12 +182,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
             });
 
             //single value test
-            contentIdFilter = new JsonNetFilterRule
+            contentIdFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "ContentTypeId",
@@ -98,21 +199,18 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            contentIdFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(contentIdFilter));
-
             contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
             Assert.IsTrue(contentIdFilteredList != null);
             Assert.IsTrue(contentIdFilteredList.Count == 2);
             Assert.IsTrue(contentIdFilteredList.All(p => (new List<int>() { 1 }).Contains(p.ContentTypeId)));
 
             //expect two entries to match for an integer comparison
-            var nullableContentIdFilter = new JsonNetFilterRule
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "NullableContentTypeId",
@@ -124,8 +222,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            nullableContentIdFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(nullableContentIdFilter));
             var nullableContentIdFilteredList =
                 StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
             Assert.IsTrue(nullableContentIdFilteredList != null);
@@ -137,12 +233,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
 
 
             //expect 3 entries to match for a case-insensitive string comparison
-            var longerTextToFilterFilter = new JsonNetFilterRule
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "LongerTextToFilter",
@@ -154,8 +250,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            longerTextToFilterFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(longerTextToFilterFilter));
             var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
             Assert.IsTrue(longerTextToFilterList != null);
             Assert.IsTrue(longerTextToFilterList.Count == 3);
@@ -164,12 +258,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     .All(p => p == "there is something interesting about this text"));
 
             //expect 3 entries to match for a case-insensitive string comparison
-            var longerTextToFilterFilterCaps = new JsonNetFilterRule
+            var longerTextToFilterFilterCaps = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "LongerTextToFilter",
@@ -181,8 +275,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            longerTextToFilterFilterCaps = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(longerTextToFilterFilterCaps));
             var longerTextToFilterListCaps = StartingQuery.BuildQuery(longerTextToFilterFilterCaps).ToList();
             Assert.IsTrue(longerTextToFilterListCaps != null);
             Assert.IsTrue(longerTextToFilterListCaps.Count == 3);
@@ -192,12 +284,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
 
 
             //expect 4 entries to match for a Date comparison
-            var lastModifiedFilter = new JsonNetFilterRule
+            var lastModifiedFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "LastModified",
@@ -209,8 +301,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            lastModifiedFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(lastModifiedFilter));
             var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
             Assert.IsTrue(lastModifiedFilterList != null);
             Assert.IsTrue(lastModifiedFilterList.Count == 4);
@@ -227,12 +317,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
             });
 
             //expect 3 entries to match for a possibly empty Date comparison
-            var nullableLastModifiedFilter = new JsonNetFilterRule
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "LastModifiedIfPresent",
@@ -244,8 +334,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            nullableLastModifiedFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(nullableLastModifiedFilter));
             var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
             Assert.IsTrue(nullableLastModifiedFilterList != null);
             Assert.IsTrue(nullableLastModifiedFilterList.Count == 3);
@@ -255,12 +343,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
 
 
             //expect 2 entries to match for a double field
-            var statValueFilter = new JsonNetFilterRule
+            var statValueFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "StatValue",
@@ -272,8 +360,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            statValueFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(statValueFilter));
             var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
             Assert.IsTrue(statValueFilterList != null);
             Assert.IsTrue(statValueFilterList.Count == 3);
@@ -290,12 +376,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
             });
 
             //expect 2 entries to match for a nullable double field
-            var nullableStatValueFilter = new JsonNetFilterRule
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "PossiblyEmptyStatValue",
@@ -307,8 +393,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            nullableStatValueFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(nullableStatValueFilter));
             var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
             Assert.IsTrue(nullableStatFilterList != null);
             Assert.IsTrue(nullableStatFilterList.Count == 2);
@@ -317,12 +401,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     .All(p => p == 1.112));
 
             //expect 2 entries to match for a List<DateTime> field
-            var dateListFilter = new JsonNetFilterRule
+            var dateListFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "DateList",
@@ -334,8 +418,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            dateListFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(dateListFilter));
             var dateListFilterList = StartingQuery.ToList().BuildQuery(dateListFilter).ToList();
             Assert.IsTrue(dateListFilterList != null);
             Assert.IsTrue(dateListFilterList.Count == 3);
@@ -350,12 +432,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
             });
 
             //expect 2 entries to match for a List<string> field
-            var strListFilter = new JsonNetFilterRule
+            var strListFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "StrList",
@@ -367,20 +449,18 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            strListFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(strListFilter));
             var strListFilterList = StartingQuery.AsEnumerable().BuildQuery(strListFilter).ToList();
             Assert.IsTrue(strListFilterList != null);
             Assert.IsTrue(strListFilterList.Count == 3);
             Assert.IsTrue(strListFilterList.All(p => p.StrList.Contains("Str2")));
 
             //expect 2 entries to match for a List<int> field
-            var intListFilter = new JsonNetFilterRule
+            var intListFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "IntList",
@@ -392,8 +472,6 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            intListFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(intListFilter));
             var intListFilterList = StartingQuery.BuildQuery(intListFilter).ToList();
             Assert.IsTrue(intListFilterList != null);
             Assert.IsTrue(intListFilterList.Count == 3);
@@ -408,12 +486,12 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
             });
 
             //expect 2 entries to match for a nullable nullable int field
-            var nullableIntListFilter = new JsonNetFilterRule
+            var nullableIntListFilter = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "IntNullList",
@@ -425,19 +503,17 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            nullableIntListFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(nullableIntListFilter));
             var nullableIntListList = StartingQuery.BuildQuery(nullableIntListFilter).ToList();
             Assert.IsTrue(nullableIntListList != null);
             Assert.IsTrue(nullableIntListList.Count == 3);
             Assert.IsTrue(nullableIntListList.All(p => p.IntNullList.Contains(5)));
 
-            var multipleWithBlankRule = new JsonNetFilterRule
+            var multipleWithBlankRule = new SystemTextJsonFilterRule
             {
                 Condition = "and",
-                Rules = new List<JsonNetFilterRule>
+                Rules = new List<SystemTextJsonFilterRule>
                 {
-                    new JsonNetFilterRule
+                    new SystemTextJsonFilterRule
                     {
                         Condition = "and",
                         Field = "StrList",
@@ -449,14 +525,2588 @@ namespace Castle.DynamicLinqQueryBuilder.Tests31
                     }
                 }
             };
-
-            multipleWithBlankRule = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(multipleWithBlankRule));
             var multipleWithBlankList = StartingQuery.BuildQuery(multipleWithBlankRule).ToList();
             Assert.IsTrue(multipleWithBlankList != null);
             Assert.IsTrue(multipleWithBlankList.Count == 4);
             Assert.IsTrue(multipleWithBlankList.All(p => p.StrList.Contains("") || p.StrList.Contains("Str2")));
+
+            //expect 2 entries to match for a nullable double field
+            var nullableWrappedStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "double",
+                        Value = new[] {new Wrapper(1.112D), new Wrapper(1.113D) }
+                    }
+                }
+            };
+            var nullableWrappedStatFilterList = StartingQuery.BuildQuery(nullableWrappedStatValueFilter).ToList();
+            Assert.IsTrue(nullableWrappedStatFilterList != null);
+            Assert.IsTrue(nullableWrappedStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableWrappedStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p == 1.112));
         }
+
+        [Test]
+        public void NotInClause()
+        {
+            //expect two entries to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "integer",
+                        Value = new[] { 1,2 }
+                    }
+                }
+            };
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 1);
+            Assert.IsTrue(contentIdFilteredList.All(p => (new List<int>() { 3 }).Contains(p.ContentTypeId)));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //expect two entries to match for an integer comparison
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "integer",
+                        Value = new[] { 1, 2 }
+                    }
+                }
+            };
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 2);
+            Assert.IsTrue(
+                nullableContentIdFilteredList.All(p => !(new List<int>() { 1, 2 }).Contains(p.NullableContentTypeId.GetValueOrDefault())));
+
+
+
+
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "string",
+                        Value = "there is something interesting about this text"
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 1);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter)
+                    .All(p => p == null || p != "there is something interesting about this text"));
+
+
+            //expect 4 entries to match for a Date comparison
+            var lastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "datetime",
+                        Value = new[] { DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture), DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) }
+                    }
+                }
+            };
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 0);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => p == DateTime.UtcNow.Date));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 3 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "datetime",
+                        Value = new[] { DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture), DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture) }
+                    }
+                }
+            };
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 1);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => p != DateTime.UtcNow.Date));
+
+
+            //expect 2 entries to match for a double field
+            var statValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "double",
+                        Value = new[] { 1.11D, 1.12D }
+                    }
+                }
+            };
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 1);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => !(new List<double>() { 1.11, 1.12 }).Contains(p)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable double field
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "double",
+                        Value = new object[] { 1.112D, 1.113D }
+                    }
+                }
+            };
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p != 1.112));
+
+
+
+
+
+
+
+            //expect 2 entries to match for a List<DateTime> field
+            var dateListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "DateList",
+                        Id = "DateList",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var dateListFilterList = StartingQuery.BuildQuery(dateListFilter).ToList();
+            Assert.IsTrue(dateListFilterList != null);
+            Assert.IsTrue(dateListFilterList.Count == 1);
+            Assert.IsTrue(dateListFilterList.All(p => !p.DateList.Contains(DateTime.UtcNow.Date.AddDays(-2))));
+
+            //expect failure when an invalid date is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                dateListFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(dateListFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a List<string> field
+            var strListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StrList",
+                        Id = "StrList",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "string",
+                        Value = "Str2"
+                    }
+                }
+            };
+            var strListFilterList = StartingQuery.BuildQuery(strListFilter).ToList();
+            Assert.IsTrue(strListFilterList != null);
+            Assert.IsTrue(strListFilterList.Count == 1);
+            Assert.IsTrue(strListFilterList.All(p => !p.StrList.Contains("Str2")));
+
+
+
+
+
+
+
+
+
+            //expect 2 entries to match for a List<int> field
+            var intListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IntList",
+                        Id = "IntList",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "integer",
+                        Value = new[] { 1 ,3 }
+                    }
+                }
+            };
+            var intListFilterList = StartingQuery.BuildQuery(intListFilter).ToList();
+            Assert.IsTrue(intListFilterList != null);
+            Assert.IsTrue(intListFilterList.Count == 1);
+            Assert.IsTrue(intListFilterList.All(p => !p.IntList.Contains(1) && !p.IntList.Contains(3)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                intListFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(intListFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable nullable int field
+            var nullableIntListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IntNullList",
+                        Id = "IntNullList",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "integer",
+                        Value = "5"
+                    }
+                }
+            };
+            var nullableIntListList = StartingQuery.BuildQuery(nullableIntListFilter).ToList();
+            Assert.IsTrue(nullableIntListList != null);
+            Assert.IsTrue(nullableIntListList.Count == 1);
+            Assert.IsTrue(
+                nullableIntListList.All(p => !p.IntNullList.Contains(5)));
+
+            //expect 2 entries to match for a nullable double field
+            var nullableWrappedStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "not_in",
+                        Type = "double",
+                        Value = new[] {new Wrapper(1.112D), new Wrapper(1.113D) }
+                    }
+                }
+            };
+            var nullableWrappedStatFilterList = StartingQuery.BuildQuery(nullableWrappedStatValueFilter).ToList();
+            Assert.IsTrue(nullableWrappedStatFilterList != null);
+            Assert.IsTrue(nullableWrappedStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableWrappedStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p != 1.112));
+
+
+
+        }
+
+        [Test]
+        public void IsNullClause()
+        {
+            //expect 1 entries to match for a case-insensitive string comparison (nullable type)
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "is_null",
+                        Type = "string",
+                        Value = ""
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 1);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter)
+                    .All(p => p == null));
+
+
+            //expect 0 entries to match for a non-nullable type
+            var contentTypeIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "is_null",
+                        Type = "integer",
+                        Value = ""
+                    }
+                }
+            };
+            var contentTypeIdFilterList = StartingQuery.BuildQuery(contentTypeIdFilter).ToList();
+            Assert.IsTrue(contentTypeIdFilterList != null);
+            Assert.IsTrue(contentTypeIdFilterList.Count == 0);
+            Assert.IsTrue(
+                contentTypeIdFilterList.Select(p => p.ContentTypeId)
+                    .All(p => p == 0));
+
+        }
+
+        [Test]
+        public void IsNotNullClause()
+        {
+            //expect 3 entries to match for a case-insensitive string comparison (nullable type)
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "is_not_null",
+                        Type = "string",
+                        Value = ""
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 3);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter)
+                    .All(p => p != null));
+
+
+            //expect 0 entries to match for a non-nullable type
+            var contentTypeIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "is_not_null",
+                        Type = "integer",
+                        Value = ""
+                    }
+                }
+            };
+            var contentTypeIdFilterList = StartingQuery.BuildQuery(contentTypeIdFilter).ToList();
+            Assert.IsTrue(contentTypeIdFilterList != null);
+            Assert.IsTrue(contentTypeIdFilterList.Count == 4);
+            Assert.IsTrue(
+                contentTypeIdFilterList.Select(p => p.ContentTypeId)
+                    .All(p => p != 0));
+
+        }
+
+        [Test]
+        public void IsEmptyClause()
+        {
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "is_empty",
+                        Type = "string",
+                        Value = ""
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 0);
+
+
+            //expect 2 entries to match for a List<DateTime> field
+            var dateListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "DateList",
+                        Id = "DateList",
+                        Input = "NA",
+                        Operator = "is_empty",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var dateListFilterList = StartingQuery.BuildQuery(dateListFilter).ToList();
+            Assert.IsTrue(dateListFilterList != null);
+            Assert.IsTrue(dateListFilterList.Count == 0);
+            //Assert.IsTrue(dateListFilterList.All(p => !p.DateList.Contains(DateTime.UtcNow.Date.AddDays(-2))));
+
+
+
+            //expect 2 entries to match for a List<string> field
+            var strListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StrList",
+                        Id = "StrList",
+                        Input = "NA",
+                        Operator = "is_empty",
+                        Type = "string",
+                        Value = "Str2"
+                    }
+                }
+            };
+            var strListFilterList = StartingQuery.BuildQuery(strListFilter).ToList();
+            Assert.IsTrue(strListFilterList != null);
+            Assert.IsTrue(strListFilterList.Count == 0);
+            //Assert.IsTrue(strListFilterList.All(p => !p.StrList.Contains("Str2")));
+
+
+            //expect 2 entries to match for a List<int> field
+            var intListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IntList",
+                        Id = "IntList",
+                        Input = "NA",
+                        Operator = "is_empty",
+                        Type = "integer",
+                        Value = new[] { 1, 3 }
+                    }
+                }
+            };
+            var intListFilterList = StartingQuery.BuildQuery(intListFilter).ToList();
+            Assert.IsTrue(intListFilterList != null);
+            Assert.IsTrue(intListFilterList.Count == 0);
+
+
+
+        }
+
+        [Test]
+        public void IsNotEmptyClause()
+        {
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "is_not_empty",
+                        Type = "string",
+                        Value = ""
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 4);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter)
+                    .All(p => p == null || p.Length > 0));
+
+
+            //expect 2 entries to match for a List<DateTime> field
+            var dateListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "DateList",
+                        Id = "DateList",
+                        Input = "NA",
+                        Operator = "is_not_empty",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var dateListFilterList = StartingQuery.BuildQuery(dateListFilter).ToList();
+            Assert.IsTrue(dateListFilterList != null);
+            Assert.IsTrue(dateListFilterList.Count == 4);
+            //Assert.IsTrue(dateListFilterList.All(p => !p.DateList.Contains(DateTime.UtcNow.Date.AddDays(-2))));
+
+
+
+            //expect 2 entries to match for a List<string> field
+            var strListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StrList",
+                        Id = "StrList",
+                        Input = "NA",
+                        Operator = "is_not_empty",
+                        Type = "string",
+                        Value = "Str2"
+                    }
+                }
+            };
+            var strListFilterList = StartingQuery.BuildQuery(strListFilter).ToList();
+            Assert.IsTrue(strListFilterList != null);
+            Assert.IsTrue(strListFilterList.Count == 4);
+            //Assert.IsTrue(strListFilterList.All(p => !p.StrList.Contains("Str2")));
+
+
+            //expect 2 entries to match for a List<int> field
+            var intListFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IntList",
+                        Id = "IntList",
+                        Input = "NA",
+                        Operator = "is_not_empty",
+                        Type = "integer",
+                        Value = new[] {1, 3 }
+                    }
+                }
+            };
+            var intListFilterList = StartingQuery.BuildQuery(intListFilter).ToList();
+            Assert.IsTrue(intListFilterList != null);
+            Assert.IsTrue(intListFilterList.Count == 4);
+
+        }
+
+        [Test]
+        public void ContainsClause()
+        {
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "contains",
+                        Type = "string",
+                        Value = "something interesting"
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 3);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
+                    .All(p => p.Contains("something interesting")));
+
+        }
+
+        [Test]
+        public void NotContainsClause()
+        {
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "not_contains",
+                        Type = "string",
+                        Value = "something interesting"
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 1);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter)
+                    .All(p => p == null));
+
+        }
+
+        [Test]
+        public void NotEndsWithClause()
+        {
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "not_ends_with",
+                        Type = "string",
+                        Value = "about this text"
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 1);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter)
+                    .All(p => p == null));
+
+        }
+
+        [Test]
+        public void EndsWithClause()
+        {
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "ends_with",
+                        Type = "string",
+                        Value = "about this text"
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 3);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
+                    .All(p => p.EndsWith("about this text")));
+
+        }
+
+        [Test]
+        public void NotBeginsWithClause()
+        {
+            //expect 1 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "not_begins_with",
+                        Type = "string",
+                        Value = "there is something"
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 1);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter)
+                    .All(p => p == null));
+
+        }
+
+        [Test]
+        public void BeginsWithClause()
+        {
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "begins_with",
+                        Type = "string",
+                        Value = "there is something"
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 3);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
+                    .All(p => p.StartsWith("there is something")));
+
+        }
+
+        [Test]
+        public void EqualsClause()
+        {
+
+            //expect two entries to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "integer",
+                        Value = "1"
+                    }
+                }
+            };
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 2);
+            Assert.IsTrue(contentIdFilteredList.All(p => p.ContentTypeId == 1));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //expect two entries to match for an integer comparison
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "integer",
+                        Value = "1"
+                    }
+                }
+            };
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 1);
+            Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId == 1));
+
+
+
+
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "string",
+                        Value = "there is something interesting about this text"
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 3);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
+                    .All(p => p == "there is something interesting about this text"));
+
+
+            //expect 4 entries to match for a Date comparison
+            var lastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 4);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => p == DateTime.UtcNow.Date));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 3 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 3);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => p == DateTime.UtcNow.Date));
+
+
+
+
+
+
+
+            //expect 3 entries to match for a boolean field
+            var isSelectedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IsSelected",
+                        Id = "IsSelected",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "boolean",
+                        Value = true
+                    }
+                }
+            };
+            var isSelectedFilterList = StartingQuery.BuildQuery(isSelectedFilter).ToList();
+            Assert.IsTrue(isSelectedFilterList != null);
+            Assert.IsTrue(isSelectedFilterList.Count == 3);
+            Assert.IsTrue(
+                isSelectedFilterList.Select(p => p.IsSelected)
+                    .All(p => p == true));
+
+            //expect failure when an invalid bool is encountered in bool comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                isSelectedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(isSelectedFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable boolean field
+            var nullableIsSelectedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IsPossiblyNotSetBool",
+                        Id = "IsPossiblyNotSetBool",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "boolean",
+                        Value = true
+                    }
+                }
+            };
+            var nullableIsSelectedFilterList = StartingQuery.BuildQuery(nullableIsSelectedFilter).ToList();
+            Assert.IsTrue(nullableIsSelectedFilterList != null);
+            Assert.IsTrue(nullableIsSelectedFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableIsSelectedFilterList.Select(p => p.IsPossiblyNotSetBool)
+                    .All(p => p == true));
+
+
+            //expect 2 entries to match for a double field
+            var statValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "double",
+                        Value = 1.11D
+                    }
+                }
+            };
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 2);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => p == 1.11));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable boolean field
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "double",
+                        Value = 1.112D
+                    }
+                }
+            };
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p == 1.112));
+
+
+
+        }
+
+        [Test]
+        public void NotEqualsClause()
+        {
+            //expect two entries to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "not_equal",
+                        Type = "integer",
+                        Value = 1
+                    }
+                }
+            };
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 2);
+            Assert.IsTrue(contentIdFilteredList.All(p => p.ContentTypeId != 1));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //expect 3 entries to match for an integer comparison
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "not_equal",
+                        Type = "integer",
+                        Value = 1
+                    }
+                }
+            };
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 3);
+            Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId != 1));
+
+            //expect 1 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "not_equal",
+                        Type = "string",
+                        Value = "there is something interesting about this text"
+                    }
+                }
+            };
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 1);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter)
+                    .All(p => (p == null) || (p.ToLower() != "there is something interesting about this text")));
+
+
+            //expect 0 entries to match for a Date comparison
+            var lastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "not_equal",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 0);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => p == DateTime.UtcNow.Date));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 1 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "not_equal",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 1);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => p != DateTime.UtcNow.Date));
+
+
+            //expect 1 entries to match for a boolean field
+            var isSelectedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IsSelected",
+                        Id = "IsSelected",
+                        Input = "NA",
+                        Operator = "not_equal",
+                        Type = "boolean",
+                        Value = true
+                    }
+                }
+            };
+            var isSelectedFilterList = StartingQuery.BuildQuery(isSelectedFilter).ToList();
+            Assert.IsTrue(isSelectedFilterList != null);
+            Assert.IsTrue(isSelectedFilterList.Count == 1);
+            Assert.IsTrue(
+                isSelectedFilterList.Select(p => p.IsSelected)
+                    .All(p => p != true));
+
+            //expect failure when an invalid bool is encountered in bool comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                isSelectedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(isSelectedFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable boolean field
+            var nullableIsSelectedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IsPossiblyNotSetBool",
+                        Id = "IsPossiblyNotSetBool",
+                        Input = "NA",
+                        Operator = "not_equal",
+                        Type = "boolean",
+                        Value = true
+                    }
+                }
+            };
+            var nullableIsSelectedFilterList = StartingQuery.BuildQuery(nullableIsSelectedFilter).ToList();
+            Assert.IsTrue(nullableIsSelectedFilterList != null);
+            Assert.IsTrue(nullableIsSelectedFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableIsSelectedFilterList.Select(p => p.IsPossiblyNotSetBool)
+                    .All(p => p != true));
+
+
+            //expect 2 entries to match for a double field
+            var statValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "not_equal",
+                        Type = "double",
+                        Value = 1.11D
+                    }
+                }
+            };
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 2);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => p != 1.11));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable boolean field
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "not_equal",
+                        Type = "double",
+                        Value = 1.112D
+                    }
+                }
+            };
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p != 1.112));
+
+        }
+
+        [Test]
+        public void BetweenClause()
+        {
+            //expect 3 entries to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "between",
+                        Type = "integer",
+                        Value = new[] { 1, 2 }
+                    }
+                }
+            };
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 3);
+            Assert.IsTrue(contentIdFilteredList.All(p => p.ContentTypeId < 3));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for an integer comparison
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "between",
+                        Type = "integer",
+                        Value = new[] { 1, 2 }
+                    }
+                }
+            };
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 2);
+            Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId < 3));
+
+
+
+
+
+            //expect 4 entries to match for a Date comparison
+            var lastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "between",
+                        Type = "datetime",
+                        Value = new[] { DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture), DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) }
+                    }
+                }
+            };
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 4);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => (p >= DateTime.UtcNow.Date.AddDays(-2)) && (p <= DateTime.UtcNow.Date)));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 3 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "between",
+                        Type = "datetime",
+                        Value = new[] { DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture), DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) }
+                    }
+                }
+            };
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 3);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => (p >= DateTime.UtcNow.Date.AddDays(-2)) && (p <= DateTime.UtcNow.Date)));
+
+
+            //expect 3 entries to match for a double field
+            var statValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "between",
+                        Type = "double",
+                        Value = new[] { 1.0D, 1.12D }
+                    }
+                }
+            };
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 3);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => (p >= 1.0) && (p <= 1.12)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable boolean field
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "between",
+                        Type = "double",
+                        Value = new[] { 1.112D, 1.112D }
+                    }
+                }
+            };
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p == 1.112));
+
+        }
+
+        [Test]
+        public void NotBetweenClause()
+        {
+            //expect 1 entry to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "not_between",
+                        Type = "integer",
+                        Value = new[] { 1, 2 }
+                    }
+                }
+            };
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 1);
+            Assert.IsTrue(contentIdFilteredList.All(p => p.ContentTypeId < 1 || p.ContentTypeId > 2));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for an integer comparison
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "not_between",
+                        Type = "integer",
+                        Value = new[] { 1, 2 }
+                    }
+                }
+            };
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 2);
+            Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId < 1 || p.NullableContentTypeId > 2 || p.NullableContentTypeId == null));
+
+
+
+
+
+            //expect 0 entries to match for a Date comparison
+            var lastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "not_between",
+                        Type = "datetime",
+                        Value = new[] {DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture), DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) }
+                    }
+                }
+            };
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 0);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => (p <= DateTime.UtcNow.Date.AddDays(-2)) && (p >= DateTime.UtcNow.Date)));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 1 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "not_between",
+                        Type = "datetime",
+                        Value = new[] { DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture), DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) }
+                    }
+                }
+            };
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 1);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => (p <= DateTime.UtcNow.Date.AddDays(-2) && p >= DateTime.UtcNow.Date) || p == null));
+
+
+            //expect 3 entries to match for a double field
+            var statValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "not_between",
+                        Type = "double",
+                        Value = new[] { 1.0D, 1.12D }
+                    }
+                }
+            };
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 1);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => (p <= 1.0) || (p >= 1.12)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable boolean field
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "not_between",
+                        Type = "double",
+                        Value = "1.112,1.112"
+                    }
+                }
+            };
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p != 1.112));
+
+        }
+
+        [Test]
+        public void GreaterOrEqualClause()
+        {
+            //expect 1 entries to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "greater_or_equal",
+                        Type = "integer",
+                        Value = 2
+                    }
+                }
+            };
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 2);
+            Assert.IsTrue(contentIdFilteredList.All(p => p.ContentTypeId >= 2));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //expect 1 entries to match for an integer comparison
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "greater_or_equal",
+                        Type = "integer",
+                        Value = 2
+                    }
+                }
+            };
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 2);
+            Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId >= 2));
+
+
+            //expect 4 entries to match for a Date comparison
+            var lastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "greater_or_equal",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 4);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => (p >= DateTime.UtcNow.Date.AddDays(-2))));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 0 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "greater_or_equal",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 0);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => (p >= DateTime.UtcNow.Date.AddDays(1))));
+
+
+            //expect 4 entries to match for a double field
+            var statValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "greater_or_equal",
+                        Type = "double",
+                        Value = 1D
+                    }
+                }
+            };
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 4);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => (p >= 1)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable boolean field
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "greater_or_equal",
+                        Type = "double",
+                        Value = 1.112D
+                    }
+                }
+            };
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p >= 1.112));
+
+        }
+
+        [Test]
+        public void GreaterClause()
+        {
+            //expect 1 entries to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "greater",
+                        Type = "integer",
+                        Value = 2
+                    }
+                }
+            };
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 1);
+            Assert.IsTrue(contentIdFilteredList.All(p => p.ContentTypeId > 2));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //expect 1 entries to match for an integer comparison
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "greater",
+                        Type = "integer",
+                        Value = 2
+                    }
+                }
+            };
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 1);
+            Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId > 2));
+
+
+            //expect 4 entries to match for a Date comparison
+            var lastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "greater",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 4);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => (p > DateTime.UtcNow.Date.AddDays(-2))));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 0 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "greater",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 0);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => (p > DateTime.UtcNow.Date.AddDays(1))));
+
+
+            //expect 4 entries to match for a double field
+            var statValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "greater",
+                        Type = "double",
+                        Value = 1D
+                    }
+                }
+            };
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 4);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => (p > 1)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable boolean field
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "greater",
+                        Type = "double",
+                        Value = 1.112D
+                    }
+                }
+            };
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 0);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p > 1.112));
+
+        }
+
+        [Test]
+        public void LessClause()
+        {
+            //expect 2 entries to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "less",
+                        Type = "integer",
+                        Value = 2
+                    }
+                }
+            };
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 2);
+            Assert.IsTrue(contentIdFilteredList.All(p => p.ContentTypeId < 2));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //expect 1 entries to match for an integer comparison
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "less",
+                        Type = "integer",
+                        Value = 2
+                    }
+                }
+            };
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 1);
+            Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId < 2));
+
+
+            //expect 0 entries to match for a Date comparison
+            var lastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "less",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 0);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => (p <= DateTime.UtcNow.Date.AddDays(-2))));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 3 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "less",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 3);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => (p <= DateTime.UtcNow.Date.AddDays(1))));
+
+
+            //expect 3 entries to match for a double field
+            var statValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "less",
+                        Type = "double",
+                        Value = 1.13D
+                    }
+                }
+            };
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 3);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => (p <= 1.12)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable boolean field
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "less",
+                        Type = "double",
+                        Value = "1.113"
+                    }
+                }
+            };
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p < 1.113));
+
+        }
+
+        [Test]
+        public void LessOrEqualClause()
+        {
+            //expect 3 entries to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "less_or_equal",
+                        Type = "integer",
+                        Value = "2"
+                    }
+                }
+            };
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 3);
+            Assert.IsTrue(contentIdFilteredList.All(p => p.ContentTypeId <= 2));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for an integer comparison
+            var nullableContentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "less_or_equal",
+                        Type = "integer",
+                        Value = "2"
+                    }
+                }
+            };
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 2);
+            Assert.IsTrue(nullableContentIdFilteredList.All(p => p.NullableContentTypeId <= 2));
+
+
+            //expect 0 entries to match for a Date comparison
+            var lastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "less_or_equal",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 0);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => (p <= DateTime.UtcNow.Date.AddDays(-2))));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 3 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "less_or_equal",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 3);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => (p <= DateTime.UtcNow.Date.AddDays(1))));
+
+
+            //expect 3 entries to match for a double field
+            var statValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "less_or_equal",
+                        Type = "double",
+                        Value = "1.13"
+                    }
+                }
+            };
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 4);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => (p <= 1.13)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable double field
+            var nullableStatValueFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "less_or_equal",
+                        Type = "double",
+                        Value = "1.113"
+                    }
+                }
+            };
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p <= 1.113));
+
+        }
+
+        [Test]
+        public void FilterWithInvalidParameters()
+        {
+            //expect 3 entries to match for an integer comparison
+            var contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "less_or_equal",
+                        Type = "integer",
+                        Value = 2
+                    },
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "less_or_equal",
+                        Type = "integer",
+                        Value = 2
+                    }
+                }
+            };
+
+            StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            contentIdFilter.Condition = "or";
+
+            StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            StartingQuery.BuildQuery(null).ToList();
+
+            StartingQuery.BuildQuery(new SystemTextJsonFilterRule()).ToList();
+
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Type = "NOT_A_TYPE";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Type = "integer";
+                contentIdFilter.Rules.First().Operator = "NOT_AN_OPERATOR";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+            });
+        }
+
+        private class IndexedClass
+        {
+            int this[string someIndex]
+            {
+                get
+                {
+                    return 2;
+                }
+            }
+        }
+
+        [Test]
+        public void IndexedExpression_Test()
+        {
+            var rule = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Field = "ContentTypeId",
+                Id = "ContentTypeId",
+                Input = "NA",
+                Operator = "equal",
+                Type = "integer",
+                Value = 2
+            };
+
+            var result = new List<IndexedClass> { new IndexedClass() }.AsQueryable().BuildQuery(rule,
+                new BuildExpressionOptions() { UseIndexedProperty = true, IndexedPropertyName = "Item" });
+            Assert.IsTrue(result.Any());
+
+            rule.Value = 3;
+            result = new[] { new IndexedClass() }.BuildQuery(rule, true, "Item");
+            Assert.IsFalse(result.Any());
+        }
+        #endregion
     }
-    
-    #endregion
 }

--- a/Castle.DynamicLinqQueryBuilder.Tests31/SystemTextJsonTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests31/SystemTextJsonTests.cs
@@ -1,0 +1,462 @@
+﻿using Castle.DynamicLinqQueryBuilder.Tests;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace Castle.DynamicLinqQueryBuilder.Tests31
+{
+    [ExcludeFromCodeCoverage]
+    [TestFixture]
+
+    class SystemTextJsonTests
+    {
+        IQueryable<Tests.Tests.ExpressionTreeBuilderTestClass> StartingQuery;
+        IQueryable<Tests.Tests.ExpressionTreeBuilderTestClass> StartingDateQuery;
+
+        [SetUp]
+        public void Setup()
+        {
+            StartingQuery = Tests.Tests.GetExpressionTreeData().AsQueryable();
+            StartingDateQuery = Tests.Tests.GetDateExpressionTreeData().AsQueryable();
+        }
+
+        #region Wrapper
+        /// <summary>
+        /// Some libraries, such as Newtonsoft.Json, will deserialize the elements of an array (that should be placed in the <see cref="IFilterRule.Value"/>) into a wrapper object
+        /// </summary>
+        private class Wrapper
+        {
+            public object Value { get; }
+
+            public Wrapper(object value)
+            {
+                Value = value;
+            }
+
+            public override string ToString() => Value?.ToString();
+        }
+        #endregion
+
+        #region Expression Tree Builder
+        [Test]
+        public void InClause()
+        {
+            //expect two entries to match for an integer comparison
+            var contentIdFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "integer",
+                        Value = new[] { 1, 2 }
+                    }
+                }
+            };
+
+            contentIdFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(contentIdFilter));
+
+            var contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 3);
+            Assert.IsTrue(contentIdFilteredList.All(p => (new List<int>() { 1, 2 }).Contains(p.ContentTypeId)));
+
+            //expect failure when non-numeric value is encountered in integer comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                contentIdFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(contentIdFilter).ToList();
+
+            });
+
+            //single value test
+            contentIdFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "ContentTypeId",
+                        Id = "ContentTypeId",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "integer",
+                        Value = new[] { 1 }
+                    }
+                }
+            };
+
+            contentIdFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(contentIdFilter));
+
+            contentIdFilteredList = StartingQuery.BuildQuery(contentIdFilter).ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 2);
+            Assert.IsTrue(contentIdFilteredList.All(p => (new List<int>() { 1 }).Contains(p.ContentTypeId)));
+
+            //expect two entries to match for an integer comparison
+            var nullableContentIdFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableContentTypeId",
+                        Id = "NullableContentTypeId",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "integer",
+                        Value = new[] { 1, 2 }
+                    }
+                }
+            };
+
+            nullableContentIdFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(nullableContentIdFilter));
+            var nullableContentIdFilteredList =
+                StartingQuery.BuildQuery(nullableContentIdFilter).ToList();
+            Assert.IsTrue(nullableContentIdFilteredList != null);
+            Assert.IsTrue(nullableContentIdFilteredList.Count == 2);
+            Assert.IsTrue(
+                nullableContentIdFilteredList.All(p => (new List<int>() { 1, 2 }).Contains(p.NullableContentTypeId.Value)));
+
+
+
+
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "string",
+                        Value = new[] { "there is something interesting about this text", "there is something interesting about this text2" }
+                    }
+                }
+            };
+
+            longerTextToFilterFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(longerTextToFilterFilter));
+            var longerTextToFilterList = StartingQuery.BuildQuery(longerTextToFilterFilter).ToList();
+            Assert.IsTrue(longerTextToFilterList != null);
+            Assert.IsTrue(longerTextToFilterList.Count == 3);
+            Assert.IsTrue(
+                longerTextToFilterList.Select(p => p.LongerTextToFilter.ToLower())
+                    .All(p => p == "there is something interesting about this text"));
+
+            //expect 3 entries to match for a case-insensitive string comparison
+            var longerTextToFilterFilterCaps = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LongerTextToFilter",
+                        Id = "LongerTextToFilter",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "string",
+                        Value = new[] { "THERE is something interesting about this text", "there is something interesting about this text2" }
+                    }
+                }
+            };
+
+            longerTextToFilterFilterCaps = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(longerTextToFilterFilterCaps));
+            var longerTextToFilterListCaps = StartingQuery.BuildQuery(longerTextToFilterFilterCaps).ToList();
+            Assert.IsTrue(longerTextToFilterListCaps != null);
+            Assert.IsTrue(longerTextToFilterListCaps.Count == 3);
+            Assert.IsTrue(
+                longerTextToFilterListCaps.Select(p => p.LongerTextToFilter.ToLower())
+                    .All(p => p == "there is something interesting about this text"));
+
+
+            //expect 4 entries to match for a Date comparison
+            var lastModifiedFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "datetime",
+                        Value = new[] { DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture), DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture) }
+                    }
+                }
+            };
+
+            lastModifiedFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(lastModifiedFilter));
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            Assert.IsTrue(lastModifiedFilterList != null);
+            Assert.IsTrue(lastModifiedFilterList.Count == 4);
+            Assert.IsTrue(
+                lastModifiedFilterList.Select(p => p.LastModified)
+                    .All(p => p == DateTime.UtcNow.Date));
+
+            //expect failure when an invalid date is encountered in date comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                lastModifiedFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+
+            });
+
+            //expect 3 entries to match for a possibly empty Date comparison
+            var nullableLastModifiedFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "datetime",
+                        Value = new[] { DateTime.UtcNow.Date.ToString("d", CultureInfo.InvariantCulture), DateTime.UtcNow.Date.AddDays(1).ToString("d", CultureInfo.InvariantCulture) }
+                    }
+                }
+            };
+
+            nullableLastModifiedFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(nullableLastModifiedFilter));
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            Assert.IsTrue(nullableLastModifiedFilterList != null);
+            Assert.IsTrue(nullableLastModifiedFilterList.Count == 3);
+            Assert.IsTrue(
+                nullableLastModifiedFilterList.Select(p => p.LastModifiedIfPresent)
+                    .All(p => p == DateTime.UtcNow.Date));
+
+
+            //expect 2 entries to match for a double field
+            var statValueFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StatValue",
+                        Id = "StatValue",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "double",
+                        Value = new[] { 1.11d, 1.12d }
+                    }
+                }
+            };
+
+            statValueFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(statValueFilter));
+            var statValueFilterList = StartingQuery.BuildQuery(statValueFilter).ToList();
+            Assert.IsTrue(statValueFilterList != null);
+            Assert.IsTrue(statValueFilterList.Count == 3);
+            Assert.IsTrue(
+                statValueFilterList.Select(p => p.StatValue)
+                    .All(p => (new List<double>() { 1.11, 1.12 }).Contains(p)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                statValueFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(statValueFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable double field
+            var nullableStatValueFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "PossiblyEmptyStatValue",
+                        Id = "PossiblyEmptyStatValue",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "double",
+                        Value = new[] {1.112D, 1.113D }
+                    }
+                }
+            };
+
+            nullableStatValueFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(nullableStatValueFilter));
+            var nullableStatFilterList = StartingQuery.BuildQuery(nullableStatValueFilter).ToList();
+            Assert.IsTrue(nullableStatFilterList != null);
+            Assert.IsTrue(nullableStatFilterList.Count == 2);
+            Assert.IsTrue(
+                nullableStatFilterList.Select(p => p.PossiblyEmptyStatValue)
+                    .All(p => p == 1.112));
+
+            //expect 2 entries to match for a List<DateTime> field
+            var dateListFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "DateList",
+                        Id = "DateList",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "datetime",
+                        Value = DateTime.UtcNow.Date.AddDays(-2).ToString("d", CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+
+            dateListFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(dateListFilter));
+            var dateListFilterList = StartingQuery.ToList().BuildQuery(dateListFilter).ToList();
+            Assert.IsTrue(dateListFilterList != null);
+            Assert.IsTrue(dateListFilterList.Count == 3);
+            Assert.IsTrue(dateListFilterList.All(p => p.DateList.Contains(DateTime.UtcNow.Date.AddDays(-2))));
+
+            //expect failure when an invalid date is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                dateListFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(dateListFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a List<string> field
+            var strListFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StrList",
+                        Id = "StrList",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "string",
+                        Value = "Str2"
+                    }
+                }
+            };
+
+            strListFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(strListFilter));
+            var strListFilterList = StartingQuery.AsEnumerable().BuildQuery(strListFilter).ToList();
+            Assert.IsTrue(strListFilterList != null);
+            Assert.IsTrue(strListFilterList.Count == 3);
+            Assert.IsTrue(strListFilterList.All(p => p.StrList.Contains("Str2")));
+
+            //expect 2 entries to match for a List<int> field
+            var intListFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IntList",
+                        Id = "IntList",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "integer",
+                        Value = new[] {"1", "3"}
+                    }
+                }
+            };
+
+            intListFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(intListFilter));
+            var intListFilterList = StartingQuery.BuildQuery(intListFilter).ToList();
+            Assert.IsTrue(intListFilterList != null);
+            Assert.IsTrue(intListFilterList.Count == 3);
+            Assert.IsTrue(intListFilterList.All(p => p.IntList.Contains(1) || p.IntList.Contains(3)));
+
+            //expect failure when an invalid double is encountered in double comparison
+            ExceptionAssert.Throws<Exception>(() =>
+            {
+                intListFilter.Rules.First().Value = "hello";
+                StartingQuery.BuildQuery(intListFilter).ToList();
+
+            });
+
+            //expect 2 entries to match for a nullable nullable int field
+            var nullableIntListFilter = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "IntNullList",
+                        Id = "IntNullList",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "integer",
+                        Value = 5
+                    }
+                }
+            };
+
+            nullableIntListFilter = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(nullableIntListFilter));
+            var nullableIntListList = StartingQuery.BuildQuery(nullableIntListFilter).ToList();
+            Assert.IsTrue(nullableIntListList != null);
+            Assert.IsTrue(nullableIntListList.Count == 3);
+            Assert.IsTrue(nullableIntListList.All(p => p.IntNullList.Contains(5)));
+
+            var multipleWithBlankRule = new JsonNetFilterRule
+            {
+                Condition = "and",
+                Rules = new List<JsonNetFilterRule>
+                {
+                    new JsonNetFilterRule
+                    {
+                        Condition = "and",
+                        Field = "StrList",
+                        Id = "StrList",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "string",
+                        Value = new[] {"", "Str2" }
+                    }
+                }
+            };
+
+            multipleWithBlankRule = JsonSerializer.Deserialize<JsonNetFilterRule>(JsonSerializer.Serialize(multipleWithBlankRule));
+            var multipleWithBlankList = StartingQuery.BuildQuery(multipleWithBlankRule).ToList();
+            Assert.IsTrue(multipleWithBlankList != null);
+            Assert.IsTrue(multipleWithBlankList.Count == 4);
+            Assert.IsTrue(multipleWithBlankList.All(p => p.StrList.Contains("") || p.StrList.Contains("Str2")));
+        }
+    }
+    
+    #endregion
+}

--- a/Castle.DynamicLinqQueryBuilder.sln
+++ b/Castle.DynamicLinqQueryBuilder.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Castle.DynamicLinqQueryBuilder", "Castle.DynamicLinqQueryBuilder\Castle.DynamicLinqQueryBuilder.csproj", "{C73EA60C-7046-4665-8A79-0E2AA85C43EC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Castle.DynamicLinqQueryBuilder", "Castle.DynamicLinqQueryBuilder\Castle.DynamicLinqQueryBuilder.csproj", "{C73EA60C-7046-4665-8A79-0E2AA85C43EC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Castle.DynamicLinqQueryBuilder.Tests", "Castle.DynamicLinqQueryBuilder.Tests\Castle.DynamicLinqQueryBuilder.Tests.csproj", "{AA125B72-F684-4DF0-803D-7CE45C0B915F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Castle.DynamicLinqQueryBuilder.Tests31", "Castle.DynamicLinqQueryBuilder.Tests31\Castle.DynamicLinqQueryBuilder.Tests31.csproj", "{3D18C76A-C7EE-478E-8E20-9834A12706FD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,8 +23,15 @@ Global
 		{AA125B72-F684-4DF0-803D-7CE45C0B915F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AA125B72-F684-4DF0-803D-7CE45C0B915F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA125B72-F684-4DF0-803D-7CE45C0B915F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D18C76A-C7EE-478E-8E20-9834A12706FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D18C76A-C7EE-478E-8E20-9834A12706FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D18C76A-C7EE-478E-8E20-9834A12706FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D18C76A-C7EE-478E-8E20-9834A12706FD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D6D73EB7-5984-40FA-848C-D5DBE5326AB9}
 	EndGlobalSection
 EndGlobal

--- a/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
+++ b/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
@@ -55,4 +55,20 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'NETSTANDARD2_0' ">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json">
+      <Version>5.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -458,7 +458,7 @@ namespace Castle.DynamicLinqQueryBuilder
                             var bracketSplit = value.ToString().Split(new[] { "[", "]" }, StringSplitOptions.RemoveEmptyEntries);
                             var vals =
                                     bracketSplit.SelectMany(v => v.Split(new[] { ",", "\r\n" }, StringSplitOptions.None))
-                                    .Select(p => tc.ConvertFromString(null, options.CultureInfo, p.Trim())).Select(p =>
+                                    .Select(p => tc.ConvertFromString(null, options.CultureInfo, p.Trim('"').Trim())).Select(p =>
                                         Expression.Constant(p, type));
                             return vals.Distinct().ToList();
                         }
@@ -481,7 +481,7 @@ namespace Castle.DynamicLinqQueryBuilder
                             var vals =
                             value.ToString().Split(new[] { ",", "[", "]", "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
                                 .Where(p => !string.IsNullOrWhiteSpace(p))
-                                .Select(p => tc.ConvertFromString(null, options.CultureInfo, p.Trim())).Select(p =>
+                                .Select(p => tc.ConvertFromString(null, options.CultureInfo, p.Trim('"').Trim())).Select(p =>
                                     Expression.Constant(p, type));
                             return vals.ToList();
                         }

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -219,29 +219,7 @@ namespace Castle.DynamicLinqQueryBuilder
             }
             if (rule.Field != null)
             {
-                Type type;
-
-                switch (rule.Type)
-                {
-                    case "integer":
-                        type = typeof(int);
-                        break;
-                    case "double":
-                        type = typeof(double);
-                        break;
-                    case "string":
-                        type = typeof(string);
-                        break;
-                    case "date":
-                    case "datetime":
-                        type = typeof(DateTime);
-                        break;
-                    case "boolean":
-                        type = typeof(bool);
-                        break;
-                    default:
-                        throw new Exception($"Unexpected data type {rule.Type}");
-                }
+                Type type = GetCSharpType(rule.Type);
 
                 if (options.UseIndexedProperty)
                 {
@@ -264,6 +242,35 @@ namespace Castle.DynamicLinqQueryBuilder
                 }
             }
             return null;
+        }
+
+        public static System.Type GetCSharpType(string typeName)
+        {
+            Type type;
+
+            switch (typeName)
+            {
+                case "integer":
+                    type = typeof(int);
+                    break;
+                case "double":
+                    type = typeof(double);
+                    break;
+                case "string":
+                    type = typeof(string);
+                    break;
+                case "date":
+                case "datetime":
+                    type = typeof(DateTime);
+                    break;
+                case "boolean":
+                    type = typeof(bool);
+                    break;
+                default:
+                    throw new Exception($"Unexpected data type {typeName}");
+            }
+
+            return type;
         }
 
         private static Expression BuildNestedExpression(Expression expression, IEnumerator<string> propertyCollectionEnumerator, IFilterRule rule, BuildExpressionOptions options, Type type)
@@ -458,7 +465,7 @@ namespace Castle.DynamicLinqQueryBuilder
                             var bracketSplit = value.ToString().Split(new[] { "[", "]" }, StringSplitOptions.RemoveEmptyEntries);
                             var vals =
                                     bracketSplit.SelectMany(v => v.Split(new[] { ",", "\r\n" }, StringSplitOptions.None))
-                                    .Select(p => tc.ConvertFromString(null, options.CultureInfo, p.Trim('"').Trim())).Select(p =>
+                                    .Select(p => tc.ConvertFromString(null, options.CultureInfo, p.Trim())).Select(p =>
                                         Expression.Constant(p, type));
                             return vals.Distinct().ToList();
                         }
@@ -481,7 +488,7 @@ namespace Castle.DynamicLinqQueryBuilder
                             var vals =
                             value.ToString().Split(new[] { ",", "[", "]", "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
                                 .Where(p => !string.IsNullOrWhiteSpace(p))
-                                .Select(p => tc.ConvertFromString(null, options.CultureInfo, p.Trim('"').Trim())).Select(p =>
+                                .Select(p => tc.ConvertFromString(null, options.CultureInfo, p.Trim())).Select(p =>
                                     Expression.Constant(p, type));
                             return vals.ToList();
                         }

--- a/Castle.DynamicLinqQueryBuilder/SystemTextJsonFilterRule.cs
+++ b/Castle.DynamicLinqQueryBuilder/SystemTextJsonFilterRule.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+
+
+namespace Castle.DynamicLinqQueryBuilder
+{
+#if NETSTANDARD2_0
+    using System.Text.Json;
+    public class SystemTextJsonFilterRule : IFilterRule
+    {
+        /// <summary>
+        /// Condition - acceptable values are "and" and "or".
+        /// </summary>
+        /// <value>
+        /// The condition.
+        /// </value>
+        public string Condition { get; set; }
+        /// <summary>
+        /// The name of the field that the filter applies to.
+        /// </summary>
+        /// <value>
+        /// The field.
+        /// </value>
+        public string Field { get; set; }
+        /// <summary>
+        /// Gets or sets the identifier.
+        /// </summary>
+        /// <value>
+        /// The identifier.
+        /// </value>
+        public string Id { get; set; }
+        /// <summary>
+        /// Gets or sets the input.
+        /// </summary>
+        /// <value>
+        /// The input.
+        /// </value>
+        public string Input { get; set; }
+        /// <summary>
+        /// Gets or sets the operator.
+        /// </summary>
+        /// <value>
+        /// The operator.
+        /// </value>
+        public string Operator { get; set; }
+        /// <summary>
+        /// Gets or sets nested filter rules.
+        /// </summary>
+        /// <value>
+        /// The rules.
+        /// </value>
+        public List<SystemTextJsonFilterRule> Rules { get; set; }
+        /// <summary>
+        /// Gets or sets the type. Supported values are "integer", "double", "string", "date", "datetime", and "boolean".
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
+        public string Type { get; set; }
+
+        private Object _Value { get; set; }
+        /// <summary>
+        /// Gets or sets the value of the filter.
+        /// </summary>
+        /// <value>
+        /// The value.
+        /// </value>
+        /// 
+        public object Value
+        {
+            get
+            {
+                // See if this is a JsonElement
+                if (_Value is JsonElement jsonValue)
+                {
+                    System.Type myType = QueryBuilder.GetCSharpType(Type);
+                           
+                    try
+                    {
+                        IEnumerable<JsonElement> array = jsonValue.EnumerateArray();
+
+                        var outList = Array.CreateInstance(myType, jsonValue.GetArrayLength());
+                        var enumerator = 0;
+
+                        foreach (var item in jsonValue.EnumerateArray())
+                        {
+                            object typedItem = GetJsonElementAsType(item);
+                            outList.SetValue(typedItem, enumerator);
+                            enumerator++;
+                        }
+
+                        return outList;
+                    }
+                    catch (Exception ex)
+                    {
+
+                    }
+                }
+
+                return _Value;
+            }
+
+            set 
+            {
+                _Value = value;
+            }
+        }
+        
+
+        IEnumerable<IFilterRule> IFilterRule.Rules => Rules;
+
+        private object GetJsonElementAsType(JsonElement element)
+        {
+            switch (this.Type)
+            {
+                case "integer":
+                    return Int32.Parse(element.GetString());
+                    break;
+                case "double":
+                    return element.GetDouble();
+                    break;
+                case "string":
+                    return element.ToString();
+                    break;
+                case "date":
+                case "datetime":
+                    return DateTime.Parse(element.GetString());
+                    break;
+                case "boolean":
+                    return element.GetBoolean();
+                    break;
+                default:
+                    throw new Exception($"Unexpected data type {this.Type}");
+            }
+        }
+    }
+
+
+
+#endif
+}


### PR DESCRIPTION
Starting with DotNetCore 3, the new System.Text.Json namespace is used by default to deserialize objects from requests in controllers instead of Json.Net. For the most part this doesn't matter but it does when it comes to how lists are deserialized into objects. This in turn affects the JsonNetFilterRule object's "Value" property when passing lists for operators like "In".

Here is how Json.Net will parse string lists (from the tests for InClause()):

- ![image](https://user-images.githubusercontent.com/28515960/104646839-046cb300-567f-11eb-9836-ffb8bef1e10f.png)

And here is how System.Text.Json does the same:

- ![image](https://user-images.githubusercontent.com/28515960/104646900-1b130a00-567f-11eb-8562-f93b4828dc91.png)


When parsed by this library, the two values are interpreted differently, the System.Text.Json version ends up with an additional quote in the resulting query (S.T.Json version first, Json.Net seccond):

- ![image](https://user-images.githubusercontent.com/28515960/104647042-4990e500-567f-11eb-84ac-56f9b711af15.png)

This in turn means that the query is not applied as expected and no results are returned!

I have traced this particular issue with string lists to the "GetConstants" function and believe it will be very easy to resolve by simply adding an additional trim which will remove surrounding quotes.

In order to test this issue I have added an additional Nunit testing project to the solution which is built on DotNetCore 3.1 (so that it can use the System.Text.Json namespace). I made some changes to the existing testing project so that I could reference and re-use some methods in the new project. 

In the new testing project I re-created the "InClause" test and passed each filter through the System.Text.Json serializer to model the process of ASP.NetCore 3+ deserializing  an incoming request. Adding the additional trim operation fixes the issues and all existing tests still pass.

Note that I did remove the "nullableWrappedStatValueFilter" portion of the test. I'm not certain about the need for the "Wrapper" but it causes a nested "{"value": foo}" when using System.Text.Json. From what I can tell, the need for the Wrapper is based on Json.Net and may not be necessary for System.Text.Json. I would like your input on this, it is certainly possible to add extra logic to unwrap the extra object notation but I didn't want to do too much in one PR. 

Note that there is some risk in this change in that if your query included quotes at the beginning or end of the value those will be stripped since Trim() removes all occurrences from the beginning and end. If you feel this is unacceptable, we can add some extra logic to check for a single quote at the beginning and end of the value and remove only those quotes using substring or something.